### PR TITLE
balance: move most deadly of nova guns to admin-spawn

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/cargodiselost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/cargodiselost.dmm
@@ -386,12 +386,12 @@
 /obj/structure/closet/crate/secure/weapon{
 	name = "Surplus Firearms"
 	},
-/obj/item/gun/ballistic/automatic/lanca,
-/obj/item/gun/ballistic/automatic/lanca,
-/obj/item/ammo_box/magazine/lanca,
-/obj/item/ammo_box/magazine/lanca,
-/obj/item/ammo_box/magazine/lanca,
-/obj/item/ammo_box/magazine/lanca,
+/obj/item/gun/ballistic/automatic/sol_smg,
+/obj/item/gun/ballistic/automatic/sol_smg,
+/obj/item/ammo_box/magazine/c35sol_pistol/stendo,
+/obj/item/ammo_box/magazine/c35sol_pistol/stendo,
+/obj/item/ammo_box/magazine/c35sol_pistol/stendo,
+/obj/item/ammo_box/magazine/c35sol_pistol/stendo,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/cargodise_freighter/cargo)
 "fl" = (
@@ -2009,7 +2009,7 @@
 /area/ruin/space/has_grav/cargodise_freighter/bridge)
 "ES" = (
 /obj/structure/rack/gunrack,
-/obj/item/gun/ballistic/automatic/lanca,
+/obj/item/gun/ballistic/automatic/sol_smg,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/cargodise_freighter/vault)
 "Fm" = (

--- a/_maps/RandomZLevels/heretic.dmm
+++ b/_maps/RandomZLevels/heretic.dmm
@@ -2612,7 +2612,7 @@
 "Pm" = (
 /obj/structure/rack,
 /obj/item/gun/ballistic/shotgun/automatic/combat/compact,
-/obj/item/gun/ballistic/automatic/sol_rifle/machinegun,
+/obj/item/gun/ballistic/automatic/sol_smg,
 /turf/open/floor/plating,
 /area/awaymission/beach/heretic)
 "Pp" = (

--- a/_maps/RandomZLevels/maintsroom.dmm
+++ b/_maps/RandomZLevels/maintsroom.dmm
@@ -4461,7 +4461,7 @@
 /area/awaymission/caves/maintsroom)
 "qR" = (
 /obj/structure/rack,
-/obj/item/gun/ballistic/automatic/sol_rifle{
+/obj/item/gun/ballistic/automatic/sol_smg{
 	anchored = 1
 	},
 /turf/open/floor/iron/smooth,
@@ -4766,7 +4766,7 @@
 /area/awaymission/caves/maintsroom)
 "sf" = (
 /obj/structure/rack,
-/obj/item/gun/ballistic/automatic/nt20{
+/obj/item/gun/ballistic/automatic/sol_smg{
 	anchored = 1
 	},
 /turf/open/floor/iron/smooth,
@@ -9053,7 +9053,7 @@
 /area/awaymission/caves/maintsroom)
 "IW" = (
 /obj/structure/rack,
-/obj/item/gun/ballistic/automatic/napad{
+/obj/item/gun/ballistic/automatic/sol_smg{
 	anchored = 1
 	},
 /turf/open/floor/iron/smooth,

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -58571,7 +58571,7 @@
 /obj/item/gun/energy/ionrifle{
 	pixel_y = 3
 	},
-/obj/item/gun/ballistic/automatic/battle_rifle{
+/obj/item/gun/ballistic/automatic/sol_smg{
 	pixel_y = 5
 	},
 /obj/item/clothing/suit/hooded/ablative,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -3272,7 +3272,7 @@
 "aNN" = (
 /obj/structure/rack,
 /obj/item/gun/energy/ionrifle,
-/obj/item/gun/ballistic/automatic/battle_rifle{
+/obj/item/gun/ballistic/automatic/sol_smg{
 	pixel_y = 3
 	},
 /obj/item/clothing/suit/hooded/ablative,

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -57596,7 +57596,7 @@
 "qnU" = (
 /obj/structure/rack,
 /obj/item/gun/energy/ionrifle,
-/obj/item/gun/ballistic/automatic/battle_rifle{
+/obj/item/gun/ballistic/automatic/sol_smg{
 	pixel_y = 3
 	},
 /obj/item/gun/energy/temperature/security,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -15194,7 +15194,7 @@
 "frt" = (
 /obj/structure/rack,
 /obj/item/gun/energy/ionrifle,
-/obj/item/gun/ballistic/automatic/battle_rifle{
+/obj/item/gun/ballistic/automatic/sol_smg{
 	pixel_y = 3
 	},
 /obj/item/gun/energy/temperature/security,

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -58372,7 +58372,7 @@
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/ablative,
 /obj/item/gun/energy/ionrifle,
-/obj/item/gun/ballistic/automatic/battle_rifle{
+/obj/item/gun/ballistic/automatic/sol_smg{
 	pixel_y = 3
 	},
 /obj/item/gun/energy/temperature/security,

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -57713,7 +57713,7 @@
 /obj/item/clothing/suit/hooded/ablative,
 /obj/item/gun/energy/temperature/security,
 /obj/item/gun/energy/ionrifle,
-/obj/item/gun/ballistic/automatic/battle_rifle{
+/obj/item/gun/ballistic/automatic/sol_smg{
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/tile/red/half/contrasted{

--- a/_maps/shuttles/nova/pirate_nri_raider.dmm
+++ b/_maps/shuttles/nova/pirate_nri_raider.dmm
@@ -272,7 +272,6 @@
 /obj/item/gun/ballistic/shotgun/riot{
 	pixel_x = -4
 	},
-/obj/item/gun/ballistic/automatic/miecz,
 /turf/open/floor/pod,
 /area/shuttle/pirate/nri)
 "kQ" = (
@@ -281,6 +280,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/suit_storage_unit/nri,
+/obj/item/gun/ballistic/automatic/sol_smg,
 /turf/open/floor/pod,
 /area/shuttle/pirate/nri)
 "kX" = (
@@ -529,7 +529,7 @@
 /area/shuttle/pirate/nri)
 "uh" = (
 /obj/structure/rack/gunrack,
-/obj/item/gun/ballistic/automatic/lanca,
+/obj/item/gun/ballistic/automatic/sol_smg,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},

--- a/_maps/virtual_domains/ancientmilsim_nova.dmm
+++ b/_maps/virtual_domains/ancientmilsim_nova.dmm
@@ -78,8 +78,7 @@
 "cF" = (
 /obj/structure/sign/poster/random/directional/west,
 /obj/structure/rack/gunrack,
-/obj/item/gun/ballistic/automatic/wylom,
-/obj/item/gun/ballistic/automatic/miecz,
+/obj/item/gun/ballistic/automatic/sol_smg,
 /obj/item/gun/ballistic/rifle/sporterized,
 /turf/open/floor/iron,
 /area/virtual_domain/ancient_milsim/snpc_hallway)
@@ -911,7 +910,7 @@
 /area/virtual_domain/ancient_milsim/atrium)
 "wy" = (
 /obj/structure/table/wood,
-/obj/item/gun/ballistic/automatic/lanca{
+/obj/item/gun/ballistic/automatic/sol_smg{
 	pixel_y = 6;
 	pixel_x = 7
 	},
@@ -1166,7 +1165,7 @@
 /turf/open/floor/iron/smooth_large,
 /area/virtual_domain/ancient_milsim/snpc_exit)
 "Dt" = (
-/obj/item/gun/ballistic/automatic/wylom,
+/obj/item/gun/ballistic/automatic/sol_smg,
 /turf/open/misc/grass/planet/ancient_milsim,
 /area/virtual_domain/ancient_milsim/loot_camp)
 "Dw" = (
@@ -1980,7 +1979,7 @@
 /turf/closed/wall/r_wall,
 /area/virtual_domain/ancient_milsim/hallway)
 "WY" = (
-/obj/item/gun/ballistic/automatic/lanca,
+/obj/item/gun/ballistic/automatic/sol_smg,
 /turf/open/floor/plating,
 /area/virtual_domain/ancient_milsim/maintenance)
 "Xh" = (

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -256,30 +256,6 @@
 	crate_name = "disabler smg crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
 
-/datum/supply_pack/security/armory/battle_rifle
-	name = "NT BR-38 Crate"
-	desc = "An experimental energy-based ballistic battle rifle. Only available to \
-		Nanotrasen stations for security purposes. DO NOT RESELL TO OUTSIDE COMPANIES. \
-		Contains three NT BR-38 rifles and three magazines containing .38 Standard."
-	cost = CARGO_CRATE_VALUE * 100
-	contains = list(
-		/obj/item/gun/ballistic/automatic/battle_rifle = 2,
-		/obj/item/ammo_box/magazine/m38 = 4,
-	)
-	crate_name = "battle rifle crate"
-
-/datum/supply_pack/security/armory/br_mag
-	name = "NT BR-38 Magazine Crate"
-	desc = "Six .38 magazines, able to fit into the NT BR-38. Contains \
-		two standard magazines, two Hot Shot magazines and two Iceblox magazines."
-	cost = CARGO_CRATE_VALUE * 7
-	contains = list(
-		/obj/item/ammo_box/magazine/m38 = 2,
-		/obj/item/ammo_box/magazine/m38/hotshot = 2,
-		/obj/item/ammo_box/magazine/m38/iceblox =2,
-	)
-	crate_name = ".38 magazine crate"
-
 /datum/supply_pack/security/armory/exileimp
 	name = "Exile Implants Crate"
 	desc = "Contains five Exile implants."

--- a/modular_nova/modules/bitrunning/code/virtual_domains/ancient_milsim/mobs.dm
+++ b/modular_nova/modules/bitrunning/code/virtual_domains/ancient_milsim/mobs.dm
@@ -50,10 +50,10 @@
 	melee_damage_lower = 5
 	melee_damage_upper = 10
 	ai_controller = /datum/ai_controller/basic_controller/trooper/calls_reinforcements/ancient_milsim/ranged
-	r_hand = /obj/item/gun/ballistic/automatic/miecz
+	r_hand = /obj/item/gun/ballistic/automatic/sol_smg
 	loot = list(/obj/effect/mob_spawn/corpse/human/cin_soldier, /obj/effect/spawner/random/ancient_milsim/ranged)
 	/// Type of bullet we use
-	var/casingtype = /obj/item/ammo_casing/c27_54cesarzowa
+	var/casingtype = /obj/item/ammo_casing/c35sol
 	/// Sound to play when firing weapon
 	var/projectilesound = 'modular_nova/modules/modular_weapons/sounds/smg_light.ogg'
 	/// number of burst shots

--- a/modular_nova/modules/bitrunning/code/virtual_domains/ancient_milsim/mod.dm
+++ b/modular_nova/modules/bitrunning/code/virtual_domains/ancient_milsim/mod.dm
@@ -199,9 +199,9 @@
 /obj/item/mod/module/dispenser/ancient_milsim/trooper
 	name = "MOD Sol rifle-Sol rifle magazine dispenser module"
 	desc = "This module can create a single .40 Sol caliber assault rifle and additional magazines at the user's liking."
-	dispense_type = /obj/item/gun/ballistic/automatic/sol_rifle/evil
+	dispense_type = /obj/item/gun/ballistic/automatic/sol_smg
 	cooldown_time = 25 SECONDS
-	new_dispense_type = /obj/item/ammo_box/magazine/c40sol_rifle/standard
+	new_dispense_type = /obj/item/ammo_box/magazine/c35sol_pistol/stendo
 	new_cooldown_time = 15 SECONDS
 
 /obj/item/mod/module/insignia/milsim_mechanic

--- a/modular_nova/modules/blueshield/code/blueshield.dm
+++ b/modular_nova/modules/blueshield/code/blueshield.dm
@@ -114,7 +114,7 @@
 	var/static/list/selectable_gun_types = list(
 		"Takbok Revolver Set" = /obj/item/storage/toolbox/guncase/nova/pistol/trappiste_small_case/takbok,
 		"Custom Hellfire Laser Rifle" = /obj/item/gun/energy/laser/hellgun/blueshield,
-		"NT20 Submachinegun Gunset" = /obj/item/storage/toolbox/guncase/nova/nt20,
+		"Sindano Submachine Gun" = /obj/item/gun/ballistic/automatic/sol_smg,
 		"Katyusha Shotgun Gunset" = /obj/item/storage/toolbox/guncase/nova/katyusha,
 	)
 

--- a/modular_nova/modules/cargo/code/packs.dm
+++ b/modular_nova/modules/cargo/code/packs.dm
@@ -189,13 +189,6 @@
 * ARMORY
 */
 
-/datum/supply_pack/security/armory/battle_rifle
-	cost = CARGO_CRATE_VALUE * 15
-	contains = list(
-		/obj/item/gun/ballistic/automatic/battle_rifle = 3,
-		/obj/item/ammo_box/magazine/m38 = 6,
-	)
-
 /datum/supply_pack/security/armory/br_mag
 	desc = "Fourteen .38 magazines, able to fit into the NT BR-38. Contains \
 		nine standard magazines, three Hot Shot magazines and three Iceblox magazines."

--- a/modular_nova/modules/company_imports/code/armament_datums/nri_military_surplus.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/nri_military_surplus.dm
@@ -130,29 +130,9 @@
 	item_type = /obj/item/melee/baton/security/stun_gun/loaded
 	cost = PAYCHECK_COMMAND * 3 //Similarly live action roleplay'iy stun baton lite
 
-/datum/armament_entry/company_import/nri_surplus/firearm/miecz
-	item_type = /obj/item/gun/ballistic/automatic/miecz
-	cost = PAYCHECK_COMMAND * 10
-	restricted = TRUE
-
-/datum/armament_entry/company_import/nri_surplus/firearm/napad
-	item_type = /obj/item/gun/ballistic/automatic/napad
-	cost = PAYCHECK_COMMAND * 12
-	restricted = TRUE
-
 /datum/armament_entry/company_import/nri_surplus/firearm/sakhno_rifle
 	item_type = /obj/item/gun/ballistic/rifle/boltaction
 	cost = PAYCHECK_COMMAND * 12
-	restricted = TRUE
-
-/datum/armament_entry/company_import/nri_surplus/firearm/lanca
-	item_type = /obj/item/gun/ballistic/automatic/lanca
-	cost = PAYCHECK_COMMAND * 14
-	restricted = TRUE
-
-/datum/armament_entry/company_import/nri_surplus/firearm/anti_materiel_rifle
-	item_type = /obj/item/gun/ballistic/automatic/wylom
-	cost = PAYCHECK_COMMAND * 16
 	restricted = TRUE
 
 /datum/armament_entry/company_import/nri_surplus/firearm_ammo
@@ -165,18 +145,5 @@
 /datum/armament_entry/company_import/nri_surplus/firearm_ammo/plasma_battery
 	item_type = /obj/item/ammo_box/magazine/recharge/plasma_battery
 
-/datum/armament_entry/company_import/nri_surplus/firearm_ammo/miecz
-	item_type = /obj/item/ammo_box/magazine/miecz/spawns_empty
-
-/datum/armament_entry/company_import/nri_surplus/firearm_ammo/napad
-	item_type = /obj/item/ammo_box/magazine/napad/spawns_empty
-
 /datum/armament_entry/company_import/nri_surplus/firearm_ammo/sakhno
 	item_type = /obj/item/ammo_box/strilka310
-
-/datum/armament_entry/company_import/nri_surplus/firearm_ammo/lanca
-	item_type = /obj/item/ammo_box/magazine/lanca/spawns_empty
-
-/datum/armament_entry/company_import/nri_surplus/firearm_ammo/amr_magazine
-	item_type = /obj/item/ammo_box/magazine/wylom
-	cost = PAYCHECK_CREW * 3

--- a/modular_nova/modules/company_imports/code/armament_datums/sol_defense.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/sol_defense.dm
@@ -122,31 +122,9 @@
 /datum/armament_entry/company_import/sol_defense/longarm/type213
 	item_type = /obj/item/gun/ballistic/automatic/type213
 
-/datum/armament_entry/company_import/sol_defense/longarm/br38
-	item_type = /obj/item/gun/ballistic/automatic/battle_rifle
-	cost = PAYCHECK_COMMAND * 8
-
-/datum/armament_entry/company_import/sol_defense/longarm/elite
-	item_type = /obj/item/gun/ballistic/automatic/sol_rifle/marksman
-	cost = PAYCHECK_COMMAND * 12
-
-/datum/armament_entry/company_import/sol_defense/longarm/bogseo
-	item_type = /obj/item/gun/ballistic/automatic/xhihao_smg
-	cost = PAYCHECK_COMMAND * 10
-
 /datum/armament_entry/company_import/sol_defense/longarm/jager
 	item_type = /obj/item/gun/ballistic/shotgun/katyusha/jager
 	cost = PAYCHECK_COMMAND * 20
-
-/datum/armament_entry/company_import/sol_defense/longarm/infanterie
-	item_type = /obj/item/gun/ballistic/automatic/sol_rifle
-	cost = PAYCHECK_COMMAND * 14
-
-/* //
-datum/armament_entry/company_import/sol_defense/longarm/outomaties
-	item_type = /obj/item/gun/ballistic/automatic/sol_rifle/machinegun
-	cost = PAYCHECK_COMMAND * 23 
-*/ //Commented out due to a severe lack of balance regarding it.
 
 /datum/armament_entry/company_import/sol_defense/longarm/kiboko
 	item_type = /obj/item/gun/ballistic/automatic/sol_grenade_launcher

--- a/modular_nova/modules/faction/code/mapping/mapping_helpers.dm
+++ b/modular_nova/modules/faction/code/mapping/mapping_helpers.dm
@@ -187,12 +187,6 @@
 			for(var/i in 1 to 2)
 				new /obj/item/ammo_box/magazine/c35sol_pistol/stendo(src)
 				new /obj/item/ammo_box/magazine/c35sol_pistol/stendo(src)
-			new /obj/item/gun/ballistic/automatic/lanca(src)
-			for(var/i in 1 to 2)
-				new /obj/item/ammo_box/magazine/lanca(src)
-			new /obj/item/gun/ballistic/automatic/miecz(src)
-			for(var/i in 1 to 2)
-				new /obj/item/ammo_box/magazine/miecz(src)
 
 		if(4) //MODsuits
 			new /obj/item/mod/control/pre_equipped/mining(src)

--- a/modular_nova/modules/goofsec/code/sol_fed.dm
+++ b/modular_nova/modules/goofsec/code/sol_fed.dm
@@ -541,12 +541,12 @@ GLOBAL_LIST_INIT(call911_do_and_do_not, list(
 	l_pocket = /obj/item/restraints/handcuffs
 	r_pocket = /obj/item/flashlight/seclite
 	id = /obj/item/card/id/advanced/solfed
-	r_hand = /obj/item/gun/ballistic/automatic/sol_rifle
+	r_hand = /obj/item/gun/ballistic/automatic/sol_smg
 	backpack_contents = list(
 		/obj/item/storage/box/handcuffs = 1,
 		/obj/item/sacrificial_face_shield = 1,
 		/obj/item/melee/baton/security/loaded = 1,
-		/obj/item/ammo_box/magazine/c40sol_rifle/standard = 4,
+		/obj/item/ammo_box/magazine/c35sol_pistol/stendo = 4,
 	)
 
 	id_trim = /datum/id_trim/solfed

--- a/modular_nova/modules/mapping/code/lockers/cargodiselost/cargodiselockers.dm
+++ b/modular_nova/modules/mapping/code/lockers/cargodiselost/cargodiselockers.dm
@@ -25,7 +25,7 @@
 /obj/structure/closet/secure_closet/personal/cabinet/freighterboss/PopulateContents()
 	. = ..()
 
-	new /obj/item/gun/ballistic/automatic/sol_rifle/marksman(src)
+	new /obj/item/gun/ballistic/automatic/sol_smg(src)
 	new /obj/item/storage/pouch/ammo(src)
 	new /obj/item/clothing/suit/armor/bulletproof(src)
 	new /obj/item/storage/belt/utility/syndicate(src)
@@ -33,6 +33,6 @@
 	new /obj/item/clothing/gloves/combat(src)
 	new /obj/item/storage/backpack/duffelbag/syndie(src)
 	new /obj/item/radio(src)
-	new /obj/item/ammo_box/magazine/c40sol_rifle(src)
-	new /obj/item/ammo_box/magazine/c40sol_rifle(src)
-	new /obj/item/ammo_box/magazine/c40sol_rifle(src)
+	new /obj/item/ammo_box/magazine/c35sol_pistol/stendo(src)
+	new /obj/item/ammo_box/magazine/c35sol_pistol/stendo(src)
+	new /obj/item/ammo_box/magazine/c35sol_pistol/stendo(src)

--- a/modular_nova/modules/mapping/code/mob_spawns.dm
+++ b/modular_nova/modules/mapping/code/mob_spawns.dm
@@ -52,8 +52,6 @@
 		/obj/item/gun/energy/e_gun/old = 50,
 		/obj/item/gun/ballistic/shotgun/automatic/combat = 50,
 		/obj/item/gun/ballistic/automatic/pistol/contraband = 30,
-		/obj/item/gun/ballistic/automatic/sol_rifle/evil  = 20,
-		/obj/item/gun/ballistic/automatic/sol_smg/evil = 20,
 		/obj/item/gun/ballistic/shotgun/bulldog/unrestricted,
 	)
 

--- a/modular_nova/modules/modular_weapons/code/cargo_crates/surplus_crates.dm
+++ b/modular_nova/modules/modular_weapons/code/cargo_crates/surplus_crates.dm
@@ -47,9 +47,7 @@
 		/obj/item/gun/ballistic/automatic/pistol/plasma_thrower = ITEM_WEIGHT_GUN_COMMON,
 		/obj/item/gun/ballistic/automatic/pistol/plasma_marksman = ITEM_WEIGHT_GUN_COMMON,
 		/obj/item/storage/toolbox/guncase/soviet/sakhno = ITEM_WEIGHT_GUN_COMMON,
-		/obj/item/gun/ballistic/automatic/miecz = ITEM_WEIGHT_GUN_RARE,
-		/obj/item/gun/ballistic/automatic/lanca = ITEM_WEIGHT_GUN_RARE,
-		/obj/item/gun/ballistic/automatic/wylom = ITEM_WEIGHT_GUN_RARE,
+		/obj/item/gun/ballistic/automatic/sol_smg = ITEM_WEIGHT_GUN_RARE,
 		// Ammo
 		/obj/item/storage/toolbox/ammobox/strilka310 = ITEM_WEIGHT_AMMO_BULK,
 		/obj/item/storage/toolbox/ammobox/strilka310/surplus = ITEM_WEIGHT_AMMO_BULK,

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/gunsets.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/gunsets.dm
@@ -40,22 +40,6 @@
 /obj/item/storage/toolbox/guncase/nova/carwo_large_case/sindano/evil
 	weapon_to_spawn = /obj/item/gun/ballistic/automatic/sol_smg/evil/no_mag
 
-// For the armory, generic-john-halo rifle.
-
-/obj/item/storage/toolbox/guncase/nova/carwo_large_case/sol_rifle
-	name = "\improper MR-2543 Rifle Kit"
-
-	weapon_to_spawn = /obj/item/gun/ballistic/automatic/sol_rifle/no_mag
-	extra_to_spawn = /obj/item/ammo_box/magazine/c40sol_rifle/starts_empty
-
-/obj/item/storage/toolbox/guncase/nova/carwo_large_case/sol_rifle/PopulateContents()
-	new weapon_to_spawn (src)
-
-	generate_items_inside(list(
-		/obj/item/ammo_box/c40sol = 3,
-		/obj/item/ammo_box/magazine/c40sol_rifle/starts_empty = 2,
-	), src)
-
 // Boxed grenade launcher, grenades sold seperately on this one
 
 /obj/item/storage/toolbox/guncase/nova/carwo_large_case/kiboko_magless

--- a/modular_nova/modules/modular_weapons/code/overrides/mystery_box_additions.dm
+++ b/modular_nova/modules/modular_weapons/code/overrides/mystery_box_additions.dm
@@ -1,10 +1,6 @@
 GLOBAL_LIST_INIT(nova_special_firearms, list(
 	/obj/item/storage/toolbox/guncase/nova/carwo_large_case/thunderdome_kiboko,
 	/obj/item/storage/toolbox/guncase/nova/carwo_large_case/thunderdome_kiboko/evil,
-	/obj/item/gun/ballistic/automatic/sol_rifle,
-	/obj/item/gun/ballistic/automatic/sol_rifle/evil,
-	/obj/item/gun/ballistic/automatic/sol_rifle/marksman,
-	/obj/item/gun/ballistic/automatic/sol_rifle/machinegun,
 	/obj/item/gun/ballistic/shotgun/riot/sol/thunderdome,
 	/obj/item/gun/ballistic/shotgun/riot/sol/evil/thunderdome,
 	/obj/item/gun/ballistic/automatic/sol_smg,
@@ -14,16 +10,12 @@ GLOBAL_LIST_INIT(nova_special_firearms, list(
 	/obj/item/gun/ballistic/automatic/pistol/plasma_thrower,
 	/obj/item/gun/ballistic/automatic/pistol/plasma_marksman,
 	/obj/item/gun/ballistic/revolver/shotgun_revolver,
-	/obj/item/gun/ballistic/automatic/lanca,
-	/obj/item/gun/ballistic/automatic/wylom,
-	/obj/item/gun/ballistic/automatic/miecz,
 	/obj/item/gun/ballistic/automatic/pistol/sol,
 	/obj/item/gun/ballistic/automatic/pistol/sol/evil,
 	/obj/item/gun/ballistic/automatic/pistol/trappiste,
 	/obj/item/gun/ballistic/revolver/sol,
 	/obj/item/gun/ballistic/revolver/takbok,
 	/obj/item/gun/ballistic/rifle/sporterized,
-	/obj/item/gun/ballistic/automatic/xhihao_smg,
 ))
 
 GLOBAL_LIST_INIT(nova_funny_mystery_box_items, list(

--- a/modular_nova/modules/sec_haul/code/guns/armory_spawns.dm
+++ b/modular_nova/modules/sec_haul/code/guns/armory_spawns.dm
@@ -76,9 +76,9 @@
 
 /obj/effect/spawner/armory_spawn/centcom_rifles
 	guns = list(
-		/obj/item/gun/ballistic/automatic/sol_rifle,
-		/obj/item/gun/ballistic/automatic/sol_rifle,
-		/obj/item/gun/ballistic/automatic/sol_rifle/machinegun,
+		/obj/item/gun/ballistic/automatic/sol_smg,
+		/obj/item/gun/ballistic/automatic/sol_smg,
+		/obj/item/gun/ballistic/automatic/sol_smg,
 	)
 
 /obj/effect/spawner/armory_spawn/centcom_lasers
@@ -93,6 +93,6 @@
 	guns = list(
 		/obj/item/storage/toolbox/guncase/nova/carwo_large_case/sindano,
 		/obj/item/storage/toolbox/guncase/nova/carwo_large_case/sindano,
-		/obj/item/storage/toolbox/guncase/nova/carwo_large_case/sol_rifle,
-		/obj/item/storage/toolbox/guncase/nova/carwo_large_case/sol_rifle,
+		/obj/item/storage/toolbox/guncase/nova/carwo_large_case/sindano,
+		/obj/item/storage/toolbox/guncase/nova/carwo_large_case/sindano,
 	)

--- a/modular_nova/modules/sec_haul/code/security_clothing/armadyne_clothing.dm
+++ b/modular_nova/modules/sec_haul/code/security_clothing/armadyne_clothing.dm
@@ -149,13 +149,13 @@
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/armadyne
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
 	suit = /obj/item/clothing/suit/armor/vest/armadyne/armor
-	suit_store = /obj/item/gun/ballistic/automatic/sol_rifle
+	suit_store = /obj/item/gun/ballistic/automatic/sol_smg
 	shoes = /obj/item/clothing/shoes/jackboots/armadyne
 	belt = /obj/item/storage/belt/security/webbing/armadyne
 	backpack_contents = list(
 		/obj/item/storage/toolbox/guncase/nova/pistol/trappiste_small_case/wespe,
 		/obj/item/storage/box/handcuffs,
-		/obj/item/ammo_box/magazine/c40sol_rifle/standard,
+		/obj/item/ammo_box/magazine/c35sol_pistol/stendo,
 		/obj/item/modular_computer/pda/security,
 	)
 	back = /obj/item/storage/backpack/security
@@ -167,23 +167,23 @@
 /datum/outfit/armadyne_security/high_alert
 	name = "Armadyne Corporate Security (High Alert)"
 	belt = /obj/item/storage/belt/security/webbing/armadyne
-	suit_store = /obj/item/gun/ballistic/automatic/sol_rifle
+	suit_store = /obj/item/gun/ballistic/automatic/sol_smg
 	backpack_contents = list(
 		/obj/item/melee/baton/telescopic,
 		/obj/item/storage/toolbox/guncase/nova/pistol/trappiste_small_case/wespe,
 		/obj/item/storage/box/handcuffs,
-		/obj/item/ammo_box/magazine/c40sol_rifle/standard = 2,
+		/obj/item/ammo_box/magazine/c35sol_pistol/stendo = 2,
 	)
 
 
 /datum/outfit/armadyne_security/commander/high_alert
 	name = "Armadyne Corporate Security Commander (High Alert)"
-	suit_store = /obj/item/gun/ballistic/automatic/sol_rifle
+	suit_store = /obj/item/gun/ballistic/automatic/sol_smg
 	backpack_contents = list(
 		/obj/item/melee/baton/telescopic,
 		/obj/item/storage/toolbox/guncase/nova/pistol/trappiste_small_case/skild,
 		/obj/item/storage/box/handcuffs,
-		/obj/item/ammo_box/magazine/c40sol_rifle/standard = 2,
+		/obj/item/ammo_box/magazine/c35sol_pistol/stendo = 2,
 	)
 
 /obj/item/card/id/advanced/armadyne


### PR DESCRIPTION
Вырезаны со всех руин/карт/карго:
/obj/item/gun/ballistic/automatic/miecz
/obj/item/gun/ballistic/automatic/lanca
/obj/item/gun/ballistic/automatic/wylom
/obj/item/gun/ballistic/automatic/battle_rifle
/obj/item/gun/ballistic/automatic/sol_rifle/marksman
/obj/item/gun/ballistic/automatic/sol_rifle
/obj/item/gun/ballistic/automatic/sol_rifle/evil
/obj/item/gun/ballistic/automatic/sol_rifle/machinegun
/obj/item/gun/ballistic/automatic/napad
/obj/item/gun/ballistic/automatic/xhihao_smg
/obj/item/gun/ballistic/automatic/nt20
Заменены на:
/obj/item/gun/ballistic/automatic/sol_smg

## Changelog

:cl:
balance: Most deadly Nova's sector guns moved to admin-spawn
balance: Moved guns replaced by Sinado Submachine Gun at ruins/maps/other spawns
balance: Armory now have 2 Sinado Submachine Gun instead of 2 Sol Rifles
/:cl:
