### PR TITLE
Fix: tarkon cards

### DIFF
--- a/modular_ss220/modules/rolesedit/code/tarkon/tarkon.dm
+++ b/modular_ss220/modules/rolesedit/code/tarkon/tarkon.dm
@@ -2,16 +2,24 @@
 	assignment = "P-T Visitor"
 	sechud_icon_state = SECHUD_ASSISTANT
 
-/obj/item/card/id/advanced/tarkon
-	name = "Tarkon visitor pass"
-
 /datum/id_trim/away/tarkon/deck
 	assignment = "P-T Deck Worker"
 	sechud_icon_state = SECHUD_BRIDGE_ASSISTANT
 
+/datum/id_trim/away/tarkon/robo
+	assignment = "P-T Cyborg Access"
+	sechud_icon_state = SECHUD_ROBOTICIST
+
+/datum/id_trim/away/tarkon/director
+	sechud_icon_state = SECHUD_CAPTAIN
+
+/obj/item/card/id/advanced/tarkon
+	name = "Tarkon visitor pass"
+
 /obj/item/card/id/advanced/tarkon/deck
 	name = "P-T deck worker's access card"
 	desc = "An access card designated for \"civilians\". You are professional assistant."
+	trim = /datum/id_trim/away/tarkon/deck
 
 /datum/outfit/tarkon
 	id_trim = /datum/id_trim/away/tarkon/deck


### PR DESCRIPTION
## Changelog

дофиксил то что ранее пропустил-теперь у директора таркона худ капитана а не такой же как у прапорщика, карта роботеха теперь обладает нормальным описанием "профессии" а так же худом роботехника, так же наклеил трим на карту ассистента таркона(для самой игры не было таковым багом, так как трим добавляется автоматом от аутфита, это больше если намапить эту карту/заспавнить

:cl:
fix: fixed a minor tarkon card issues
/:cl:
