### PR TITLE
fix: DNR revival typo

### DIFF
--- a/code/modules/surgery/revival.dm
+++ b/code/modules/surgery/revival.dm
@@ -121,7 +121,7 @@
 
 	//NOVA EDIT CHANGE - DNR TRAIT - need this so that people don't just keep spamming the revival surgery; it runs success just bc the surgery steps are done
 	if(HAS_TRAIT(target, TRAIT_DNR))
-		target.visible_message(span_warning("...[target.p_they()] lie[target.p_s()] still, unaffected. Further attempts are futile, target.p_theyre() gone."))
+		target.visible_message(span_warning("...[target.p_they()] lie[target.p_s()] still, unaffected. Further attempts are futile, [target.p_theyre()] gone."))
 	else
 		target.visible_message(span_warning("...[target.p_they()] convulse[target.p_s()], then lie[target.p_s()] still."))
 	//NOVA EDIT CHANGE END - DNR TRAIT - ORIGINAL: target.visible_message(span_warning("...[target.p_they()] convulse[target.p_s()], then lie[target.p_s()] still."))


### PR DESCRIPTION
## Changelog

:cl:
fix: DNR revival typo "target.p_theyre()"
/:cl:
