### PR TITLE
config: dynamic correct required enemies

### DIFF
--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -37,16 +37,16 @@
 				10
 			],
 			"required_enemies": [
+				2,
 				1,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0
+				1,
+				1,
+				1,
+				1,
+				1,
+				1,
+				1,
+				1
 			],
 			"antag_cap": {
 				"denominator": 10
@@ -89,15 +89,15 @@
 			],
 			"required_enemies": [
 				2,
-				1,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0
+				2,
+				2,
+				2,
+				2,
+				2,
+				2,
+				2,
+				2,
+				2
 			],
 			"antag_cap": {
 				"denominator": 30,
@@ -142,14 +142,14 @@
 			"required_enemies": [
 				3,
 				2,
-				1,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0
+				2,
+				2,
+				2,
+				2,
+				2,
+				2,
+				2,
+				2
 			],
 			"antag_cap": {
 				"denominator": 15
@@ -196,14 +196,14 @@
 			"required_enemies": [
 				3,
 				2,
-				1,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0
+				2,
+				2,
+				2,
+				2,
+				2,
+				2,
+				2,
+				2
 			],
 			"antag_cap": {
 				"denominator": 15
@@ -247,9 +247,9 @@
 				3,
 				3,
 				2,
+				2,
+				2,
 				1,
-				0,
-				0,
 				0,
 				0,
 				0,
@@ -289,13 +289,13 @@
 				5,
 				4,
 				3,
+				3,
+				3,
 				2,
-				1,
-				0,
-				0,
-				0,
-				0,
-				0
+				2,
+				2,
+				2,
+				2
 			],
 			"antag_cap": {
 				"denominator": 20,
@@ -385,12 +385,12 @@
 				3,
 				3,
 				2,
-				1,
-				0,
-				0,
-				0,
-				0,
-				0
+				2,
+				2,
+				2,
+				2,
+				2,
+				2
 			],
 			"antag_cap": 3,
 			"protected_roles": [
@@ -437,10 +437,10 @@
 				3,
 				3,
 				2,
+				2,
+				2,
 				1,
-				0,
-				0,
-				0,
+				1,
 				0,
 				0,
 				0
@@ -520,15 +520,15 @@
 			],
 			"required_enemies": [
 				1,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0
+				1,
+				1,
+				1,
+				1,
+				1,
+				1,
+				1,
+				1,
+				1
 			],
 			"antag_cap": {
 				"denominator": 10
@@ -563,7 +563,7 @@
 			"minimum_players": 5,
 			"minimum_required_age": 0,
 			"requirements": [10, 10, 10, 10, 10, 10, 10, 10, 10, 10],
-			"required_enemies": [ 1, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+			"required_enemies": [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ],
 			"antag_cap": {
 				"denominator": 24
 			},
@@ -602,7 +602,18 @@
 				10,
 				10
 			],
-			"required_enemies": [ 3, 2, 1, 0, 0, 0, 0, 0, 0, 0 ],
+			"required_enemies": [
+				3,
+				3,
+				2,
+				2,
+				2,
+				1,
+				1,
+				0,
+				0,
+				0
+			],
 			"antag_cap": {
 				"denominator": 50
 			},
@@ -676,7 +687,18 @@
 				10,
 				10
 			],
-			"required_enemies": [ 3, 2, 2, 1, 0, 0, 0, 0, 0, 0 ],
+			"required_enemies": [
+				3,
+				3,
+				2,
+				2,
+				2,
+				1,
+				0,
+				0,
+				0,
+				0
+			],
 			"antag_cap": {
 				"denominator": 24
 			},
@@ -707,7 +729,7 @@
 				20,
 				10
 			],
-			"required_enemies": [ 3, 3, 3, 2, 1, 0, 0, 0, 0, 0 ],
+			"required_enemies": [ 3, 3, 3, 2, 2, 2, 2, 2, 2, 2 ],
 			"antag_cap": {
 				"denominator": 15,
 				"offset": 1
@@ -739,7 +761,7 @@
 				10,
 				10
 			],
-			"required_enemies": [ 3, 3, 3, 2, 1, 0, 0, 0, 0, 0 ],
+			"required_enemies": [ 3, 3, 3, 2, 2, 2, 2, 2, 2, 2 ],
 			"antag_cap": {
 				"denominator": 15,
 				"offset": 1
@@ -770,7 +792,7 @@
 				10,
 				10
 			],
-			"required_enemies": [ 3, 3, 3, 2, 1, 0, 0, 0, 0, 0 ],
+			"required_enemies": [ 3, 3, 3, 2, 1, 1, 1, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 25
 			},
@@ -800,7 +822,7 @@
 				10,
 				10
 			],
-			"required_enemies": [ 3, 3, 3, 2, 1, 0, 0, 0, 0, 0 ],
+			"required_enemies": [ 3, 3, 3, 2, 1, 1, 1, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 25
 			},
@@ -832,7 +854,7 @@
 				10,
 				10
 			],
-			"required_enemies": [ 3, 2, 1, 0, 0, 0, 0, 0, 0, 0 ],
+			"required_enemies": [ 3, 2, 1, 1, 1, 1, 1, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 12,
 				"offset": 1
@@ -864,7 +886,7 @@
 				10,
 				10
 			],
-			"required_enemies": [ 3, 2, 1, 0, 0, 0, 0, 0, 0, 0 ],
+			"required_enemies": [ 3, 2, 1, 1, 1, 1, 1, 1, 1, 1 ],
 			"antag_cap": {
 				"denominator": 24
 			},
@@ -895,7 +917,7 @@
 				10,
 				10
 			],
-			"required_enemies": [ 3, 3, 3, 2, 1, 0, 0, 0, 0, 0 ],
+			"required_enemies": [ 3, 3, 3, 2, 1, 1, 1, 1, 1, 1 ],
 			"antag_cap": {
 				"denominator": 99
 			},
@@ -926,7 +948,7 @@
 				10,
 				10
 			],
-			"required_enemies": [ 2, 1, 1, 0, 0, 0, 0, 0, 0, 0 ],
+			"required_enemies": [ 2, 1, 1, 1, 1, 1, 1, 1, 1, 1 ],
 			"antag_cap": {
 				"denominator": 20,
 				"offset": 1
@@ -958,7 +980,7 @@
 				10,
 				10
 			],
-			"required_enemies": [ 3, 3, 3, 2, 1, 0, 0, 0, 0, 0 ],
+			"required_enemies": [ 3, 3, 3, 2, 2, 2, 2, 2, 2, 2 ],
 			"antag_cap": {
 				"denominator": 25
 			},
@@ -989,7 +1011,7 @@
 				10,
 				10
 			],
-			"required_enemies": [ 1, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+			"required_enemies": [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ],
 			"antag_cap": {
 				"denominator": 12
 			},
@@ -1020,7 +1042,7 @@
 				10,
 				10
 			],
-			"required_enemies": [ 1, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+			"required_enemies": [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ],
 			"antag_cap": {
 				"denominator": 24
 			},
@@ -1080,7 +1102,7 @@
 				10,
 				10
 			],
-			"required_enemies": [ 2, 1, 0, 0, 0, 0, 0, 0, 0, 0 ],
+			"required_enemies": [ 2, 1, 1, 1, 1, 1, 1, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 15,
 				"offset": 2
@@ -1112,7 +1134,7 @@
 				10,
 				10
 			],
-			"required_enemies": [ 2, 1, 0, 0, 0, 0, 0, 0, 0, 0 ],
+			"required_enemies": [ 2, 1, 1, 1, 1, 1, 1, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 15,
 				"offset": 3
@@ -1144,7 +1166,7 @@
 				10,
 				10
 			],
-			"required_enemies": [ 1, 1, 0, 0, 0, 0, 0, 0, 0, 0 ],
+			"required_enemies": [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ],
 			"antag_cap": {
 				"denominator": 10
 			},
@@ -1176,7 +1198,7 @@
 				10,
 				10
 			],
-			"required_enemies": [ 2, 2, 1, 0, 0, 0, 0, 0, 0, 0 ],
+			"required_enemies": [ 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 ],
 			"antag_cap": {
 				"denominator": 20
 			},
@@ -1207,7 +1229,7 @@
 				10,
 				10
 			],
-			"required_enemies": [ 1, 1, 0, 0, 0, 0, 0, 0, 0, 0 ],
+			"required_enemies": [ 1, 1, 1, 1, 1, 1, 1, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 10
 			},
@@ -1238,7 +1260,7 @@
 				10,
 				10
 			],
-			"required_enemies": [ 3, 2, 1, 0, 0, 0, 0, 0, 0, 0 ],
+			"required_enemies": [ 3, 2, 1, 1, 1, 1, 1, 1, 1, 1 ],
 			"antag_cap": {
 				"denominator": 24
 			},
@@ -1268,7 +1290,7 @@
 				10,
 				10
 			],
-			"required_enemies": [ 3, 2, 1, 0, 0, 0, 0, 0, 0, 0 ],
+			"required_enemies": [ 3, 2, 1, 1, 1, 1, 1, 1, 1, 1 ],
 			"antag_cap": {
 				"denominator": 99
 			},
@@ -1298,7 +1320,7 @@
 				10,
 				10
 			],
-			"required_enemies": [ 3, 2, 1, 0, 0, 0, 0, 0, 0, 0 ],
+			"required_enemies": [ 3, 2, 1, 1, 1, 1, 1, 1, 1, 1 ],
 			"antag_cap": {
 				"denominator": 99
 			},
@@ -1329,7 +1351,7 @@
 				10,
 				10
 			],
-			"required_enemies": [ 3, 2, 1, 0, 0, 0, 0, 0, 0, 0 ],
+			"required_enemies": [ 3, 2, 1, 1, 1, 1, 1, 1, 1, 1 ],
 			"antag_cap": {
 				"denominator": 18
 			},
@@ -1364,15 +1386,15 @@
 			],
 			"required_enemies": [
 				1,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0
+				1,
+				1,
+				1,
+				1,
+				1,
+				1,
+				1,
+				1,
+				1
 			],
 			"antag_cap": {
 				"denominator": 12
@@ -1416,13 +1438,13 @@
 				3,
 				3,
 				2,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0
+				2,
+				2,
+				2,
+				2,
+				2,
+				2,
+				2
 			],
 			"antag_cap": {
 				"denominator": 15
@@ -1471,14 +1493,14 @@
 			"required_enemies": [
 				2,
 				2,
-				1,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0
+				2,
+				2,
+				2,
+				2,
+				2,
+				2,
+				2,
+				2
 			],
 			"antag_cap": {
 				"denominator": 15
@@ -1523,13 +1545,13 @@
 				3,
 				3,
 				2,
-				1,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0
+				2,
+				2,
+				2,
+				2,
+				2,
+				2,
+				2
 			],
 			"antag_cap": {
 				"denominator": 15


### PR DESCRIPTION
## Changelog

:cl:
config: Dynamic rulesets now should correctly work based on enemies per threat, most rulesets require at least 1 enemy (security/captain)
/:cl: