### PR TITLE
add: DS-2 and interdyne own research server

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/des_two1984.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/des_two1984.dmm
@@ -3584,6 +3584,7 @@
 	desc = "A brick of stimulants meant for use by Tiger Cooperative agents. It seems this one's just a brittle block of heroin.";
 	name = "Tiger Coop stimulant brick"
 	},
+/obj/item/circuitboard/machine/rdserver/interdyne_ds2,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/nova/des_two/bridge/vault)
 "pk" = (
@@ -3915,6 +3916,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
+/obj/machinery/rnd/server/interdyne_ds2,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/nova/des_two/research)
 "qN" = (
@@ -9116,8 +9118,6 @@
 	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to.";
 	name = "researcher armband"
 	},
-/obj/item/clothing/suit/toggle/jacket/nova/sci,
-/obj/item/clothing/suit/toggle/jacket/nova/sci,
 /obj/item/clothing/suit/hooded/wintercoat/science,
 /turf/open/floor/iron/dark/side{
 	dir = 1
@@ -9971,8 +9971,6 @@
 /obj/item/holosign_creator/atmos{
 	pixel_y = -8
 	},
-/obj/item/clothing/suit/toggle/jacket/nova/engi,
-/obj/item/clothing/suit/toggle/jacket/nova/engi,
 /obj/item/clothing/suit/hooded/wintercoat/engineering,
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/dark/side{

--- a/code/controllers/subsystem/networks/research.dm
+++ b/code/controllers/subsystem/networks/research.dm
@@ -81,6 +81,7 @@ SUBSYSTEM_DEF(research)
 	new /datum/techweb/admin
 	new /datum/techweb/oldstation
 	new /datum/techweb/tarkon //NOVA EDIT
+	new /datum/techweb/interdyne_ds2 // SS1984 ADDITION
 	autosort_categories()
 	error_design = new
 	error_node = new

--- a/modular_ss220/modules/ghostroles_stuff/ds2_interdyne_shared/interdyne_ds2_rnd.dm
+++ b/modular_ss220/modules/ghostroles_stuff/ds2_interdyne_shared/interdyne_ds2_rnd.dm
@@ -1,0 +1,33 @@
+/obj/machinery/rnd/server/interdyne_ds2
+	name = "\improper Syndicate R&D Server"
+	circuit = /obj/item/circuitboard/machine/rdserver/interdyne_ds2
+	req_access = list(ACCESS_SYNDICATE_LEADER)
+
+/obj/machinery/rnd/server/interdyne_ds2/Initialize(mapload)
+	var/datum/techweb/tech_web = locate(/datum/techweb/interdyne_ds2) in SSresearch.techwebs
+	stored_research = tech_web
+	return ..()
+
+/obj/machinery/rnd/server/interdyne_ds2/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+
+	if(held_item && istype(held_item, /obj/item/research_notes))
+		context[SCREENTIP_CONTEXT_LMB] = "Generate research points"
+		return CONTEXTUAL_SCREENTIP_SET
+
+/obj/machinery/rnd/server/interdyne_ds2/examine(mob/user)
+	. = ..()
+
+	if(!in_range(user, src) && !isobserver(user))
+		return
+
+	. += span_notice("Insert [EXAMINE_HINT("Research Notes")] to generate points.")
+
+/obj/machinery/rnd/server/interdyne_ds2/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
+	if(istype(attacking_item, /obj/item/research_notes) && stored_research)
+		var/obj/item/research_notes/research_notes = attacking_item
+		stored_research.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = research_notes.value))
+		playsound(src, 'sound/machines/copier.ogg', 50, TRUE)
+		qdel(research_notes)
+		return
+	return ..()

--- a/modular_ss220/modules/ghostroles_stuff/ds2_interdyne_shared/machine_circuits.dm
+++ b/modular_ss220/modules/ghostroles_stuff/ds2_interdyne_shared/machine_circuits.dm
@@ -1,0 +1,3 @@
+/obj/item/circuitboard/machine/rdserver/interdyne_ds2
+	name = "Syndicate R&D Server"
+	build_path = /obj/machinery/rnd/server/interdyne_ds2

--- a/modular_ss220/modules/ghostroles_stuff/ds2_interdyne_shared/techweb_types.dm
+++ b/modular_ss220/modules/ghostroles_stuff/ds2_interdyne_shared/techweb_types.dm
@@ -1,0 +1,4 @@
+/datum/techweb/interdyne_ds2
+	id = "SYNDICATE_AWAY"
+	organization = "Syndicate"
+	should_generate_points = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9440,4 +9440,7 @@
 #include "modular_ss220\modules\qol_casual_1984\healthanalyzer_autolathe\medical_designs.dm"
 #include "modular_ss220\modules\qol_casual_1984\nanodrug_pills\medical.dm"
 #include "modular_ss220\modules\qol_casual_1984\atmos_engi_skillchip\atmospheric_technician.dm"
+#include "modular_ss220\modules\ghostroles_stuff\ds2_interdyne_shared\techweb_types.dm"
+#include "modular_ss220\modules\ghostroles_stuff\ds2_interdyne_shared\machine_circuits.dm"
+#include "modular_ss220\modules\ghostroles_stuff\ds2_interdyne_shared\interdyne_ds2_rnd.dm"
 // END_INCLUDE


### PR DESCRIPTION
StrongDMM удалил пару вещей с ДС-2 которых не нашел, на случай если кто-то потеряет 4 куртки на ДС-2

## Changelog

:cl:
add: Syndicate research server is added to DS-2. It's have it's own techweb separated from station. Interdyne is also gain researches from it (in case they build R&D)
add: Spare Syndicate R&D server circuit added to DS-2 vault safe
/:cl:

****
- [x] Проверено на локалке
