### PR TITLE
balance: remove ghostroles shuttle dock to station

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/des_two1984.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/des_two1984.dmm
@@ -7444,7 +7444,7 @@
 	icon_screen = "syndishuttle";
 	light_color = "#FA8282";
 	name = "syndicate cargo shuttle terminal";
-	possible_destinations = "interdyne_cargo_home;interdyne_cargo_away;interdyne_cargo_custom;whiteship_home";
+	possible_destinations = "interdyne_cargo_home;interdyne_cargo_away;interdyne_cargo_custom";
 	req_access = list("syndicate");
 	shuttleId = "interdyne_cargo"
 	},

--- a/code/modules/shuttle/misc/shuttle_remote.dm
+++ b/code/modules/shuttle/misc/shuttle_remote.dm
@@ -67,6 +67,14 @@
 	var/obj/docking_port/away = SSshuttle.getDock(shuttle_away_id)
 	var/obj/docking_port/dock = our_port.get_docked()
 
+	// SS1984 ADDITION START
+	if (allow_call_to_custom_and_backhome)
+		if ("[our_computer.shuttleId]_custom" == dock.shuttle_id || away == dock)
+			away = home
+	if (!away || !away.name)
+		return // no away location (might be custom, so it's ok)
+	// SS1984 ADDITION END
+
 	var/send_off_text = "Are you sure you want to send off [get_area_name(SSshuttle.getShuttle(our_computer.shuttleId))] to [away.name]?"
 	var/list/send_off_options = list("Yes", "No")
 	var/destination = null

--- a/modular_ss220/modules/ghostroles_stuff/shuttles_stuff/shuttles.dm
+++ b/modular_ss220/modules/ghostroles_stuff/shuttles_stuff/shuttles.dm
@@ -2,4 +2,14 @@
 	possible_destinations = "interdyne_cargo_home;interdyne_cargo_away;interdyne_cargo_custom"
 
 /obj/machinery/computer/shuttle/tarkon_driver
-	possible_destinations = "tarkon_driver_custom;port_tarkon"
+	possible_destinations = "tarkon_driver_custom;port_tarkon;whiteship_away"
+
+/obj/machinery/computer/camera_advanced/shuttle_docker/tarkon_driver
+	jump_to_ports = list("port_tarkon" = 1, "whiteship_away" = 1)
+
+/obj/item/shuttle_remote
+	var/allow_call_to_custom_and_backhome = FALSE
+
+/obj/item/shuttle_remote/tarkon
+	shuttle_away_id = "tarkon_driver_custom" // sends HREF warnings and do nothing usually
+	allow_call_to_custom_and_backhome = TRUE

--- a/modular_ss220/modules/ghostroles_stuff/shuttles_stuff/shuttles.dm
+++ b/modular_ss220/modules/ghostroles_stuff/shuttles_stuff/shuttles.dm
@@ -1,0 +1,5 @@
+/obj/machinery/computer/shuttle/interdyne_cargo
+	possible_destinations = "interdyne_cargo_home;interdyne_cargo_away;interdyne_cargo_custom"
+
+/obj/machinery/computer/shuttle/tarkon_driver
+	possible_destinations = "tarkon_driver_custom;port_tarkon"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9443,4 +9443,5 @@
 #include "modular_ss220\modules\ghostroles_stuff\ds2_interdyne_shared\techweb_types.dm"
 #include "modular_ss220\modules\ghostroles_stuff\ds2_interdyne_shared\machine_circuits.dm"
 #include "modular_ss220\modules\ghostroles_stuff\ds2_interdyne_shared\interdyne_ds2_rnd.dm"
+#include "modular_ss220\modules\ghostroles_stuff\shuttles_stuff\shuttles.dm"
 // END_INCLUDE


### PR DESCRIPTION
Больше таркон и прочие не будут воровать ресурсы станции через сило + техфаб на шаттле и печку, как минимум не так просто (минимально мозгами возможно подумают как это все еще можно абузить, пока не придумали как фиксить)

## Changelog

:cl:
balance: Ghostroles such as Tarkon, DS-2, Interdyne no longer have destination to station docks
balance: Tarkon instead of station can fly to Deep Space by using camera console (in case it was spawned)
add: Tarkon remote now can fly to any custom location and back to tarkon port (unique feature for tarkon shuttle only)
/:cl:

****
- [x] Проверено на локалке