### PR TITLE
fix: non-mim salute

### DIFF
--- a/modular_ss220/modules/localization_modular/emotes_localization/emotes.dm
+++ b/modular_ss220/modules/localization_modular/emotes_localization/emotes.dm
@@ -485,7 +485,7 @@
 /datum/emote/living/carbon/human/salute
 	name = "салютовать"
 	message = "салюту%(ет,ют)%!"
-	message = "бесшумно салюту%(ет,ют)%!"
+	message_mime = "бесшумно салюту%(ет,ют)%!"
 	message_param = "салюту%(ет,ют)% %t."
 
 /datum/emote/living/carbon/human/shrug


### PR DESCRIPTION
## Changelog

:cl:
fix: Salute is now correctly displayed as non-mime
/:cl: