### PR TITLE
balance: disable chestrig, some pocket loadout

### DIFF
--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_belts.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_belts.dm
@@ -94,30 +94,31 @@
 
 // RIGS/WEBBING (for military larpers)
 
-/datum/loadout_item/belts/cin_surplus_chestrig
-	name = "Chest Rig - CIN Surplus (Colorable)"
-	item_path = /obj/item/storage/belt/military/cin_surplus
-
-/datum/loadout_item/belts/cin_surplus_chestrig_desert
-	name = "Chest Rig - CIN Surplus (Desert)"
-	item_path = /obj/item/storage/belt/military/cin_surplus/desert
-	can_be_greyscale = DONT_GREYSCALE
-
-/datum/loadout_item/belts/cin_surplus_chestrig_forest
-	name = "Chest Rig - CIN Surplus (Forest)"
-	item_path = /obj/item/storage/belt/military/cin_surplus/forest
-	can_be_greyscale = DONT_GREYSCALE
-
-/datum/loadout_item/belts/cin_surplus_chestrig_marine
-	name = "Chest Rig - CIN Surplus (Marine)"
-	item_path = /obj/item/storage/belt/military/cin_surplus/marine
-	can_be_greyscale = DONT_GREYSCALE
-
-/datum/loadout_item/belts/expeditionary_chestrig_belt
-	name = "Chest Rig - Expeditionary"
-	item_path = /obj/item/storage/belt/military/expeditionary_corps
-
-/datum/loadout_item/belts/frontier_chestrig
-	name = "Chest Rig - Frontier"
-	item_path = /obj/item/storage/belt/utility/frontier_colonist
-
+// SS1984 REMOVAL START
+// /datum/loadout_item/belts/cin_surplus_chestrig
+// 	name = "Chest Rig - CIN Surplus (Colorable)"
+// 	item_path = /obj/item/storage/belt/military/cin_surplus
+//
+// /datum/loadout_item/belts/cin_surplus_chestrig_desert
+// 	name = "Chest Rig - CIN Surplus (Desert)"
+// 	item_path = /obj/item/storage/belt/military/cin_surplus/desert
+// 	can_be_greyscale = DONT_GREYSCALE
+//
+// /datum/loadout_item/belts/cin_surplus_chestrig_forest
+// 	name = "Chest Rig - CIN Surplus (Forest)"
+// 	item_path = /obj/item/storage/belt/military/cin_surplus/forest
+// 	can_be_greyscale = DONT_GREYSCALE
+//
+// /datum/loadout_item/belts/cin_surplus_chestrig_marine
+// 	name = "Chest Rig - CIN Surplus (Marine)"
+// 	item_path = /obj/item/storage/belt/military/cin_surplus/marine
+// 	can_be_greyscale = DONT_GREYSCALE
+//
+// /datum/loadout_item/belts/expeditionary_chestrig_belt
+// 	name = "Chest Rig - Expeditionary"
+// 	item_path = /obj/item/storage/belt/military/expeditionary_corps
+//
+// /datum/loadout_item/belts/frontier_chestrig
+// 	name = "Chest Rig - Frontier"
+// 	item_path = /obj/item/storage/belt/utility/frontier_colonist
+// SS1984 REMOVAL END

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_pocket.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_pocket.dm
@@ -129,17 +129,21 @@
 	name = "Colonial Medipen Pouch (Empty)"
 	item_path = /obj/item/storage/pouch/cin_medipens
 
-/datum/loadout_item/pocket_items/deforest_cheesekit
-	name = "Medical Kit - Civil Defense"
-	item_path = /obj/item/storage/medkit/civil_defense/stocked
+// SS1984 REMOVAL START
+// /datum/loadout_item/pocket_items/deforest_cheesekit
+// 	name = "Medical Kit - Civil Defense"
+// 	item_path = /obj/item/storage/medkit/civil_defense/stocked
+// SS1984 REMOVAL END
 
 /datum/loadout_item/pocket_items/medkit
 	name = "Medical Kit - First-Aid"
 	item_path = /obj/item/storage/medkit/regular
 
-/datum/loadout_item/pocket_items/deforest_frontiermedkit
-	name = "Medical Kit - Frontier"
-	item_path = /obj/item/storage/medkit/frontier/stocked
+// SS1984 REMOVAL START
+// /datum/loadout_item/pocket_items/deforest_frontiermedkit
+// 	name = "Medical Kit - Frontier"
+// 	item_path = /obj/item/storage/medkit/frontier/stocked
+// SS1984 REMOVAL END
 
 /datum/loadout_item/pocket_items/synthetic_medkit
 	name = "Medical Kit - Robotics"
@@ -161,17 +165,21 @@
 	name = "Neuroware Chips Box (PosiBlaster64)"
 	item_path = /obj/item/storage/box/flat/neuroware/mindbreaker
 
-/datum/loadout_item/pocket_items/binoculars
-	name = "Pair of Binoculars"
-	item_path = /obj/item/binoculars
-
-/datum/loadout_item/pocket_items/drugs_happy
-	name = "Pillbottle - Happy Pills"
-	item_path = /obj/item/storage/pill_bottle/happy
-
-/datum/loadout_item/pocket_items/drugs_lsd
-	name = "Pillbottle - Mindbreaker"
-	item_path = /obj/item/storage/pill_bottle/lsd
+// SS1984 REMOVAL START
+//
+// /datum/loadout_item/pocket_items/binoculars
+// 	name = "Pair of Binoculars"
+// 	item_path = /obj/item/binoculars
+//
+// /datum/loadout_item/pocket_items/drugs_happy
+// 	name = "Pillbottle - Happy Pills"
+// 	item_path = /obj/item/storage/pill_bottle/happy
+//
+// /datum/loadout_item/pocket_items/drugs_lsd
+// 	name = "Pillbottle - Mindbreaker"
+// 	item_path = /obj/item/storage/pill_bottle/lsd
+//
+// SS1984 REMOVAL END
 
 /datum/loadout_item/pocket_items/random_pizza
 	name = "Random Pizza Box"
@@ -185,17 +193,19 @@
 	name = "Rations - Colonial"
 	item_path = /obj/item/storage/box/colonial_rations
 
-/datum/loadout_item/pocket_items/drugs_weed
-	name = "Seeds - Cannabis"
-	item_path = /obj/item/seeds/cannabis
-
-/datum/loadout_item/pocket_items/drugs_liberty
-	name = "Seeds - Liberty Cap"
-	item_path = /obj/item/seeds/liberty
-
-/datum/loadout_item/pocket_items/drugs_reishi
-	name = "Seeds - Reishi"
-	item_path = /obj/item/seeds/reishi
+// SS1984 REMOVAL START
+// /datum/loadout_item/pocket_items/drugs_weed
+// 	name = "Seeds - Cannabis"
+// 	item_path = /obj/item/seeds/cannabis
+//
+// /datum/loadout_item/pocket_items/drugs_liberty
+// 	name = "Seeds - Liberty Cap"
+// 	item_path = /obj/item/seeds/liberty
+//
+// /datum/loadout_item/pocket_items/drugs_reishi
+// 	name = "Seeds - Reishi"
+// 	item_path = /obj/item/seeds/reishi
+// SS1984 REMOVAL END
 
 /datum/loadout_item/pocket_items/six_beer
 	name = "Six-Pack - Beer"


### PR DESCRIPTION
## Скриншоты того, что убрано

<img width="593" height="271" alt="image" src="https://github.com/user-attachments/assets/7c382084-d3da-421d-bbec-a4ebebb09048" />

<img width="465" height="427" alt="image" src="https://github.com/user-attachments/assets/01b69a5a-d1b1-44ee-8997-060c5d65af1e" />

<img width="341" height="111" alt="image" src="https://github.com/user-attachments/assets/a2541d8c-86d7-437b-af37-8ef3b0b30378" />

<img width="238" height="115" alt="image" src="https://github.com/user-attachments/assets/b2b011af-b7d7-47e2-adb0-8e4e82fcd861" />


## Changelog

:cl:
balance: Removed chestrigs from loadout
balance: Removed seeds, pills, binoculars, some medkits from loadout
/:cl:

****
- [x] Проверено на локалке
