### PR TITLE
qol: health analyzer popup window

### DIFF
--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -99,6 +99,11 @@
 	switch (scanmode)
 		if (SCANMODE_HEALTH)
 			last_scan_text = healthscan(user, M, mode, advanced, tochat = readability_check)
+			// SS1984 ADDITION START
+			last_scan_title = "Analyzing results for <b>[M]</b>"
+			if(readability_check)
+				show_results(user)
+			// SS1984 ADDITION END
 			if((M.health / M.maxHealth) > CLEAN_BILL_OF_HEALTH_RATIO)
 				last_healthy_scanned = WEAKREF(M)
 			else

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -110,7 +110,11 @@
 				last_healthy_scanned = null
 		if (SCANMODE_WOUND)
 			if(readability_check)
-				woundscan(user, M, src)
+				last_scan_text = woundscan(user, M, src) // SS1984 EDIT, original: woundscan(user, M, src)
+				// SS1984 ADDITION START
+				last_scan_title = "Wound analyze results for <b>[M]</b>"
+				show_results(user)
+				// SS1984 ADDITION END
 
 	add_fingerprint(user)
 
@@ -669,13 +673,16 @@
 			playsound(simple_scanner, 'sound/machines/ping.ogg', 50, FALSE)
 			to_chat(user, span_notice("\The [simple_scanner] makes a happy ping and briefly displays a smiley face with several exclamation points! It's really excited to report that [patient] has no wounds!"))
 			simple_scanner.show_emotion(AID_EMOTION_HAPPY)
-		to_chat(user, "<span class='notice ml-1'>No wounds detected in subject.</span>")
+		var/to_return_msg = "<span class='notice ml-1'>No wounds detected in subject.</span>" // SS1984 ADDITION
+		to_chat(user, to_return_msg) // SS1984 EDIT, original: to_chat(user, "<span class='notice ml-1'>No wounds detected in subject.</span>")
+		return to_return_msg // SS1984 ADDITION
 	else
 		to_chat(user, custom_boxed_message("blue_box", jointext(render_list, "")), type = MESSAGE_TYPE_INFO)
 		if(simple_scan)
 			var/obj/item/healthanalyzer/simple/simple_scanner = scanner
 			simple_scanner.show_emotion(AID_EMOTION_WARN)
 			playsound(simple_scanner, 'sound/machines/beep/twobeep.ogg', 50, FALSE)
+		return render_list // SS1984 ADDITION
 
 
 /obj/item/healthanalyzer/simple

--- a/modular_ss220/modules/qol_casual_1984/healthanalzer_ui/health_analyzer.dm
+++ b/modular_ss220/modules/qol_casual_1984/healthanalzer_ui/health_analyzer.dm
@@ -30,10 +30,13 @@
 	var/user_ref = href_list["user"]
 	if(!user_ref) // reference
 		return FALSE
-	var/mob/user = locate(user_ref) in GLOB.mob_list
+	var/mob/user = locate(user_ref) in GLOB.alive_mob_list
 	if (!user) // actual variable
 		return FALSE
 	winset(user, "mapwindow", "focus=true")
+
+	if(isdead(user)) // might be not necessary since GLOB.alive_mob_list, but let's keep it for safety
+		return FALSE
 
 	if(!in_range(user, src))
 		to_chat(user, span_notice("Нужно подойти ближе, чтобы нажать на кнопку."))

--- a/modular_ss220/modules/qol_casual_1984/healthanalzer_ui/health_analyzer.dm
+++ b/modular_ss220/modules/qol_casual_1984/healthanalzer_ui/health_analyzer.dm
@@ -1,0 +1,46 @@
+#define HEALTH_ANALYZER_WINDOW_WIDTH 500
+#define HEALTH_ANALYZER_WINDOW_HEIGHT 450
+
+/obj/item/healthanalyzer
+	var/last_scan_title = "Analyzing results"
+
+/obj/item/healthanalyzer/proc/show_results(mob/user)
+	if (!user)
+		return
+	var/datum/browser/popup = new(user, "scanner", last_scan_title, HEALTH_ANALYZER_WINDOW_WIDTH, HEALTH_ANALYZER_WINDOW_HEIGHT)
+	popup.set_content("[get_header(user)]<hr>[last_scan_text]")
+	popup.open()
+	ui_interact(user)
+
+/obj/item/healthanalyzer/proc/get_header(mob/user)
+	var/srcref = REF(src)
+	var/usrref = REF(user)
+	return "<a href='byond://?src=[srcref];user=[usrref];clear=1'>Очистить</a><a href='byond://?src=[srcref];user=[usrref];print=1'>Печать отчёта</a>"
+
+/obj/item/healthanalyzer/Topic(href, href_list)
+	. = ..()
+	var/user_ref = href_list["user"]
+	if(!user_ref) // reference
+		return FALSE
+	var/mob/user = locate(href_list["user"]) in GLOB.mob_list
+	if (!user) // actual variable
+		return FALSE
+	winset(user, "mapwindow", "focus=true")
+
+	if(!in_range(user, src))
+		to_chat(user, span_notice("Нужно подойти ближе, чтобы нажать на кнопку."))
+		return FALSE
+
+	if(href_list["print"])
+		click_ctrl_shift(usr)
+		return TRUE
+
+	if(href_list["clear"])
+		to_chat(usr, "Вы очистили буфер данных [src].")
+		last_scan_text = null
+		last_scan_title = ""
+		user << browse(null, "window=scanner")
+		return TRUE
+
+#undef HEALTH_ANALYZER_WINDOW_WIDTH
+#undef HEALTH_ANALYZER_WINDOW_HEIGHT

--- a/modular_ss220/modules/qol_casual_1984/healthanalzer_ui/health_analyzer.dm
+++ b/modular_ss220/modules/qol_casual_1984/healthanalzer_ui/health_analyzer.dm
@@ -15,14 +15,22 @@
 /obj/item/healthanalyzer/proc/get_header(mob/user)
 	var/srcref = REF(src)
 	var/usrref = REF(user)
-	return "<a href='byond://?src=[srcref];user=[usrref];clear=1'>Очистить</a><a href='byond://?src=[srcref];user=[usrref];print=1'>Печать отчёта</a>"
+	return "<a href='byond://?src=[srcref];user=[usrref];clear=1'>Очистить</a><a href='byond://?src=[srcref];user=[usrref];print=1'>Печать отчёта</a><a href='byond://?src=[srcref];user=[usrref];switch_mode=1'>Сменить режим</a>"
+
+/obj/item/healthanalyzer/examine(mob/user)
+	. = ..()
+	if(last_scan_text && last_scan_title)
+		if(in_range(user, src) || istype(user, /mob/dead/observer))
+			show_results(user)
+		else
+			. += span_notice("Нужно подойти ближе, чтобы прочесть содержмое.")
 
 /obj/item/healthanalyzer/Topic(href, href_list)
 	. = ..()
 	var/user_ref = href_list["user"]
 	if(!user_ref) // reference
 		return FALSE
-	var/mob/user = locate(href_list["user"]) in GLOB.mob_list
+	var/mob/user = locate(user_ref) in GLOB.mob_list
 	if (!user) // actual variable
 		return FALSE
 	winset(user, "mapwindow", "focus=true")
@@ -32,11 +40,15 @@
 		return FALSE
 
 	if(href_list["print"])
-		click_ctrl_shift(usr)
+		click_ctrl_shift(user)
+		return TRUE
+
+	if(href_list["switch_mode"])
+		attack_self(user)
 		return TRUE
 
 	if(href_list["clear"])
-		to_chat(usr, "Вы очистили буфер данных [src].")
+		to_chat(user, "Вы очистили буфер данных [src].")
 		last_scan_text = null
 		last_scan_title = ""
 		user << browse(null, "window=scanner")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9544,6 +9544,7 @@
 #include "modular_ss220\modules\qol_casual_1984\combat_info_desc_gun\gun.dm"
 #include "modular_ss220\modules\qol_casual_1984\combat_info_desc_gun\box_magazine.dm"
 #include "modular_ss220\modules\qol_casual_1984\extended_perk_description\species.dm"
+#include "modular_ss220\modules\qol_casual_1984\healthanalzer_ui\health_analyzer.dm"
 #include "modular_ss220\modules\ghostroles_stuff\ds2_interdyne_shared\techweb_types.dm"
 #include "modular_ss220\modules\ghostroles_stuff\ds2_interdyne_shared\machine_circuits.dm"
 #include "modular_ss220\modules\ghostroles_stuff\ds2_interdyne_shared\interdyne_ds2_rnd.dm"


### PR DESCRIPTION
## Скриншоты

<img width="1570" height="830" alt="image" src="https://github.com/user-attachments/assets/afc9feb9-5259-4f61-9c6d-077992502462" />
<img width="1397" height="840" alt="image" src="https://github.com/user-attachments/assets/ee6ea763-e963-4df3-9578-c580d92fc9e3" />
<img width="827" height="509" alt="image" src="https://github.com/user-attachments/assets/335dfa9a-1813-45c0-bc78-d054d585fd62" />
<img width="1447" height="844" alt="image" src="https://github.com/user-attachments/assets/ad0d3fe3-e46a-4aee-86c3-58ea1f2ffd57" />

## Changelog

:cl:
qol: Health Analyzer now shows popup after performing scan (it's the same, as written to chat). The extra buttons such as "Print", "Clear" "Switch mode" are also here
qol: You can examine Health Analyzer (in close range) to see last scan (in case there any stored)
/:cl:

****
- [x] Проверено на локалке
