### PR TITLE
balance: junk caliber casings now can fit into shotgun caliber

### DIFF
--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -104,7 +104,7 @@
 		load_type = ammo_type
 
 	var/obj/item/ammo_casing/round_check = load_type
-	if(!starting && !(caliber ? (caliber == initial(round_check.caliber)) : (ammo_type == load_type)))
+	if(!starting && !(caliber ? (caliber == initial(round_check.caliber)) : (ammo_type == load_type || (caliber == CALIBER_SHOTGUN && round_check.caliber == CALIBER_JUNK)))) // SS1984 EDIT, original: if(!starting && !(caliber ? (caliber == initial(round_check.caliber)) : (ammo_type == load_type)))
 		stack_trace("Tried loading unsupported ammocasing type [load_type] into ammo box [type].")
 		return
 
@@ -135,7 +135,7 @@
 ///puts a round into the magazine
 /obj/item/ammo_box/proc/give_round(obj/item/ammo_casing/new_round, replace_spent = 0)
 	// Boxes don't have a caliber type, magazines do. Not sure if it's intended or not, but if we fail to find a caliber, then we fall back to ammo_type.
-	if(!new_round || !(caliber ? (caliber == new_round.caliber) : (ammo_type == new_round.type)))
+	if(!new_round || !(caliber ? (caliber == new_round.caliber) : (ammo_type == new_round.type || (caliber == CALIBER_SHOTGUN && new_round.caliber == CALIBER_JUNK)))) // SS1984 EDIT, original: if(!new_round || !(caliber ? (caliber == new_round.caliber) : (ammo_type == new_round.type)))
 		return FALSE
 
 	if (stored_ammo.len < max_ammo)

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -104,7 +104,7 @@
 		load_type = ammo_type
 
 	var/obj/item/ammo_casing/round_check = load_type
-	if(!starting && !(caliber ? (caliber == initial(round_check.caliber)) : (ammo_type == load_type || (caliber == CALIBER_SHOTGUN && round_check.caliber == CALIBER_JUNK)))) // SS1984 EDIT, original: if(!starting && !(caliber ? (caliber == initial(round_check.caliber)) : (ammo_type == load_type)))
+	if(!starting && !(caliber ? (caliber == initial(round_check.caliber) || (caliber == CALIBER_SHOTGUN && round_check.caliber == CALIBER_JUNK)) : (ammo_type == load_type))) // SS1984 EDIT, original: if(!starting && !(caliber ? (caliber == initial(round_check.caliber)) : (ammo_type == load_type)))
 		stack_trace("Tried loading unsupported ammocasing type [load_type] into ammo box [type].")
 		return
 
@@ -135,7 +135,7 @@
 ///puts a round into the magazine
 /obj/item/ammo_box/proc/give_round(obj/item/ammo_casing/new_round, replace_spent = 0)
 	// Boxes don't have a caliber type, magazines do. Not sure if it's intended or not, but if we fail to find a caliber, then we fall back to ammo_type.
-	if(!new_round || !(caliber ? (caliber == new_round.caliber) : (ammo_type == new_round.type || (caliber == CALIBER_SHOTGUN && new_round.caliber == CALIBER_JUNK)))) // SS1984 EDIT, original: if(!new_round || !(caliber ? (caliber == new_round.caliber) : (ammo_type == new_round.type)))
+	if(!new_round || !(caliber ? (caliber == new_round.caliber || (caliber == CALIBER_SHOTGUN && new_round.caliber == CALIBER_JUNK)) : (ammo_type == new_round.type))) // SS1984 EDIT, original: if(!new_round || !(caliber ? (caliber == new_round.caliber) : (ammo_type == new_round.type)))
 		return FALSE
 
 	if (stored_ammo.len < max_ammo)

--- a/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
@@ -39,7 +39,7 @@
 	return no_nulls_ammo
 
 /obj/item/ammo_box/magazine/internal/cylinder/give_round(obj/item/ammo_casing/R, replace_spent = 0)
-	if(!R || !(caliber ? (caliber == R.caliber) : (ammo_type == R.type || (caliber == CALIBER_SHOTGUN && R.caliber == CALIBER_JUNK)))) // SS1984 EDIT, original: if(!R || !(caliber ? (caliber == R.caliber) : (ammo_type == R.type)))
+	if(!R || !(caliber ? (caliber == R.caliber || (caliber == CALIBER_SHOTGUN && R.caliber == CALIBER_JUNK)) : (ammo_type == R.type))) // SS1984 EDIT, original: if(!R || !(caliber ? (caliber == R.caliber) : (ammo_type == R.type)))
 		return FALSE
 
 	for(var/i in 1 to stored_ammo.len)

--- a/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
@@ -39,7 +39,7 @@
 	return no_nulls_ammo
 
 /obj/item/ammo_box/magazine/internal/cylinder/give_round(obj/item/ammo_casing/R, replace_spent = 0)
-	if(!R || !(caliber ? (caliber == R.caliber) : (ammo_type == R.type)))
+	if(!R || !(caliber ? (caliber == R.caliber) : (ammo_type == R.type || (caliber == CALIBER_SHOTGUN && R.caliber == CALIBER_JUNK)))) // SS1984 EDIT, original: if(!R || !(caliber ? (caliber == R.caliber) : (ammo_type == R.type)))
 		return FALSE
 
 	for(var/i in 1 to stored_ammo.len)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -549,7 +549,7 @@
 /obj/item/gun/ballistic/proc/load_gun(obj/item/ammo, mob/living/user)
 	if (chambered && !chambered.loaded_projectile)
 		chambered.forceMove(drop_location())
-		if(chambered != magazine?.stored_ammo[1])
+		if(magazine && magazine.stored_ammo.len > 0 && chambered != magazine.stored_ammo[1]) // SS1984 EDIT, original: if(chambered != magazine?.stored_ammo[1])
 			magazine.stored_ammo -= chambered
 		set_chambered(null) // SS1984 EDIT, original: chambered = null
 


### PR DESCRIPTION
## Changelog

:cl:
balance: Junk caliber casings now can be loaded into shotguns (to anything with shotgun caliber, however shotgun shells still can't be loaded in pipegun)
/:cl:

****
- [x] Проверено на локалке
