### PR TITLE
fix: shoulder holster attached icon size

### DIFF
--- a/modular_ss220/modules/security_minor_1984/shoulder_holsters/shoulder_holster.dm
+++ b/modular_ss220/modules/security_minor_1984/shoulder_holsters/shoulder_holster.dm
@@ -10,6 +10,7 @@
 	var/obj/item/gun/holstered = null
 	actions_types = list(/datum/action/item_action/accessory/holster)
 	w_class = WEIGHT_CLASS_NORMAL // so it doesn't fit in pockets
+	minimize_when_attached = FALSE
 
 /obj/item/clothing/accessory/holster/Destroy()
 	if(holstered?.loc == src) // Gun still in the holster


### PR DESCRIPTION
## Changelog

:cl:
fix: Shouler holster when attached now have proper icon size
/:cl:

****
- [x] Проверено на локалке