### PR TITLE
qol: holster now require free hand to draw + fix icon better way

### DIFF
--- a/modular_ss220/modules/security_minor_1984/shoulder_holsters/accessory_actions.dm
+++ b/modular_ss220/modules/security_minor_1984/shoulder_holsters/accessory_actions.dm
@@ -1,8 +1,9 @@
-// for clothing accessories like holsters
-/datum/action/item_action/accessory
-	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_CONSCIOUS
+/datum/action/item_action/accessory/holster
+	name = "Holster"
+	button_icon = 'icons/obj/clothing/accessories.dmi'
+	button_icon_state = "holster"
 
-/datum/action/item_action/accessory/IsAvailable(feedback = FALSE)
+/datum/action/item_action/accessory/holster/IsAvailable(feedback = FALSE)
 	. = ..()
 	if(!.)
 		return FALSE
@@ -14,6 +15,3 @@
 	if(istype(item_target.loc, /obj/item/clothing/under) && item_target.loc.loc == owner)
 		return TRUE
 	return FALSE
-
-/datum/action/item_action/accessory/holster
-	name = "Holster"

--- a/modular_ss220/modules/security_minor_1984/shoulder_holsters/shoulder_holster.dm
+++ b/modular_ss220/modules/security_minor_1984/shoulder_holsters/shoulder_holster.dm
@@ -10,7 +10,6 @@
 	var/obj/item/gun/holstered = null
 	actions_types = list(/datum/action/item_action/accessory/holster)
 	w_class = WEIGHT_CLASS_NORMAL // so it doesn't fit in pockets
-	minimize_when_attached = FALSE
 
 /obj/item/clothing/accessory/holster/Destroy()
 	if(holstered?.loc == src) // Gun still in the holster


### PR DESCRIPTION
## Changelog

:cl:
qol: Shoulder holster now doesn't draw gun (drop it) when hands are not usable (full)
fix: Shoulder holster icon now properly scaled at uniform
/:cl:

****
- [x] Проверено на локалке
