### PR TITLE
admin: forced rulesets now can be forced without can_be_selected() check

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -444,6 +444,7 @@ SUBSYSTEM_DEF(dynamic)
 		CRASH("force_run_midround() was called with an invalid midround type: [midround_typepath]")
 
 	var/datum/dynamic_ruleset/midround/running = new midround_typepath(dynamic_config)
+	running.can_always_be_selected = TRUE // SS1984 ADDITION
 	if(isnum(forced_max_cap) && forced_max_cap > 0)
 		running.min_antag_cap = min(forced_max_cap, running.min_antag_cap)
 		running.max_antag_cap = forced_max_cap

--- a/code/controllers/subsystem/dynamic/dynamic_admin.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_admin.dm
@@ -126,6 +126,12 @@ ADMIN_VERB(dynamic_panel, R_ADMIN, "Dynamic Panel", "Mess with dynamic.", ADMIN_
 			if(!ruleset_path)
 				return
 			SSdynamic.queue_ruleset(ruleset_path)
+			// SS1984 ADDITION START
+			if (islist(SSdynamic.queued_rulesets) && SSdynamic.queued_rulesets.len > 0)
+				var/datum/dynamic_ruleset/ruleset_instance = SSdynamic.queued_rulesets[SSdynamic.queued_rulesets.len]
+				if (ruleset_instance)
+					ruleset_instance.can_always_be_selected = TRUE
+			// SS1984 ADDITION END
 			message_admins("[key_name_admin(ui.user)] added [initial(ruleset_path.config_tag)] to the dynamic ruleset queue.")
 			log_admin("[key_name_admin(ui.user)] added [initial(ruleset_path.config_tag)] to the dynamic ruleset queue.")
 			return TRUE

--- a/modular_ss220/modules/dynamic_tweaks/dynamic_ruleset.dm
+++ b/modular_ss220/modules/dynamic_tweaks/dynamic_ruleset.dm
@@ -20,6 +20,7 @@
 		JOB_BLUESHIELD,
 		JOB_NT_REP,
 	)
+	var/can_always_be_selected = FALSE // used primary for admin-forced, basically just skips entirely proc: can_be_selected()
 
 /datum/dynamic_ruleset/proc/get_minimal_num_of_enemies(tier = DYNAMIC_TIER_LOW)
 	if (islist(min_enemies))
@@ -60,6 +61,8 @@
 	return 0
 
 /datum/dynamic_ruleset/can_be_selected()
+	if (can_always_be_selected)
+		return TRUE
 	. = ..()
 	if (!.)
 		return .


### PR DESCRIPTION
## Changelog

:cl:
admin: Forcing dynamic rulesets now skipping checks, that would prevent it from spawning normally (like required amount of enemies)
/:cl:

****
- [x] Проверено на локалке
