### PR TITLE
balance: 50 glass and iron sheets near cargo autolathe & small map fixes

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -1725,6 +1725,12 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = -8
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "atG" = (
@@ -6257,29 +6263,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"bBL" = (
-/obj/structure/table/reinforced,
-/obj/item/disk/tech_disk{
-	pixel_x = -6
-	},
-/obj/item/disk/tech_disk{
-	pixel_x = 6
-	},
-/obj/item/disk/tech_disk{
-	pixel_y = 6
-	},
-/obj/structure/sign/warning/no_smoking/directional/west,
-/obj/effect/turf_decal/siding/purple{
-	dir = 4
-	},
-/obj/item/book/manual/wiki/research_and_development,
-/obj/item/toy/figure/scientist,
-/obj/item/stack/sheet/iron/ten,
-/obj/item/stack/sheet/glass{
-	amount = 10
-	},
-/turf/open/floor/iron,
-/area/station/science/lab)
 "bCc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -10020,14 +10020,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"cIY" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security EVA"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/smooth,
-/area/station/security/brig/upper)
 "cJb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/north,
@@ -41702,6 +41694,13 @@
 	},
 /obj/item/food/cheesiehonkers,
 /obj/machinery/firealarm/directional/south,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "lMg" = (
@@ -50453,17 +50452,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/black,
 /area/station/security/prison/safe)
-"olY" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security EVA"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/smooth,
-/area/station/security/processing)
 "omg" = (
 /obj/effect/spawner/random/clothing/wardrobe_closet_colored,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -58570,14 +58558,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/range)
-"qwd" = (
-/obj/machinery/light_switch/directional/south,
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/checkpoint/supply)
 "qwe" = (
 /obj/structure/table,
 /obj/item/phone{

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -49571,7 +49571,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Security EVA"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -60064,7 +60064,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Security EVA"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron/smooth,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -294,11 +294,6 @@
 /mob/living/simple_animal/bot/secbot/beepsky/armsky,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
-"agd" = (
-/obj/effect/turf_decal/tile/red/fourcorners,
-/obj/structure/closet/secure_closet/security/sec,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/supply)
 "agi" = (
 /obj/effect/spawner/random/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -997,18 +992,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
-"asT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/autolathe,
-/obj/machinery/door/window/left/directional/east{
-	name = "Cargo Autolathe";
-	req_access = list("cargo")
-	},
-/turf/open/floor/iron,
-/area/station/cargo/lobby)
 "atf" = (
 /obj/structure/table/glass,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -58790,7 +58773,7 @@
 /turf/open/floor/carpet,
 /area/station/service/theater)
 "uii" = (
-/obj/effect/spawner/structure/window,
+/obj/machinery/autolathe,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -58799,7 +58782,13 @@
 	name = "Cargo Lockdown Shutters";
 	id = "cargolockdown"
 	},
-/turf/open/floor/plating,
+/obj/structure/window/reinforced/tinted/spawner/directional,
+/obj/structure/window/reinforced/tinted/spawner/directional/north,
+/obj/machinery/door/window/left/directional/east{
+	name = "Cargo Autolathe";
+	req_access = list("cargo")
+	},
+/turf/open/floor/iron,
 /area/station/cargo/lobby)
 "uiw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -59840,6 +59829,14 @@
 /obj/item/stamp{
 	pixel_x = -9;
 	pixel_y = -1
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = -2;
+	pixel_y = 16
+	},
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = -8;
+	pixel_y = 16
 	},
 /turf/open/floor/catwalk_floor/iron,
 /area/station/cargo/storage)

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -42027,27 +42027,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"nDR" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/item/stock_parts/matter_bin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/micro_laser,
-/obj/item/multitool,
-/obj/item/flatpack{
-	board = /obj/item/circuitboard/machine/flatpacker
-	},
-/obj/item/stack/sheet/glass{
-	amount = 10
-	},
-/obj/item/stack/sheet/iron/ten,
-/turf/open/floor/iron/white,
-/area/station/science/lab)
 "nDX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -52363,6 +52342,12 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/machinery/light/directional/north,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = -8
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "rom" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -44661,6 +44661,10 @@
 /obj/machinery/light_switch/directional/west{
 	pixel_y = -4
 	},
+/obj/item/stack/sheet/iron/ten,
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "oDH" = (


### PR DESCRIPTION
## Скриншоты:

### Meta
<img width="396" height="375" alt="image" src="https://github.com/user-attachments/assets/05b9cc6d-f3dc-4e1c-824e-a50e43301a3c" />

### Delta
<img width="794" height="518" alt="image" src="https://github.com/user-attachments/assets/0256721d-b1a9-465e-b9ef-2fba58d40343" />


### Icebox
<img width="567" height="605" alt="image" src="https://github.com/user-attachments/assets/37ba79b3-52ee-4856-b1f4-ded3509c2aa9" />

### Tram
<img width="863" height="617" alt="image" src="https://github.com/user-attachments/assets/05ba2952-cb9c-464c-98fa-481c23383606" />


## Changelog

:cl:
fix: Metastation missed cargo autolathe is added back
fix: Fixed required access back to brig on security EVA on some maps
balance: Added 50 iron & glass sheets to cargo, at table not far away from autolathe. For all recommended maps: Delta, Meta, Icebox, Tram
/:cl:

****
- [x] Проверено на локалке
