### PR TITLE
balance: revert (modular) "adds 1.2s fire delay to ion gun."

### DIFF
--- a/modular_ss220/modules/balance-1984/no_ion_delay/special.dm
+++ b/modular_ss220/modules/balance-1984/no_ion_delay/special.dm
@@ -1,0 +1,3 @@
+/obj/item/gun/energy/ionrifle/Initialize(mapload)
+	. = ..()
+	fire_delay = 0 // idk why nova does it on initialize(), but now we have to do the same

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9507,6 +9507,7 @@
 #include "modular_ss220\modules\balance-1984\hunterslug\shotgun.dm"
 #include "modular_ss220\modules\balance-1984\greandes_projectiles\grenade.dm"
 #include "modular_ss220\modules\balance-1984\advanced_egun_taser\energy_gun.dm"
+#include "modular_ss220\modules\balance-1984\no_ion_delay\special.dm"
 #include "modular_ss220\modules\sol_pistol_incapacitator\magazines.dm"
 #include "modular_ss220\modules\sol_pistol_incapacitator\pistol.dm"
 #include "modular_ss220\modules\security_vouchers\closets\secure\security.dm"


### PR DESCRIPTION
## Changelog

:cl:
balance: Revert "adds 1.2s fire delay to ion gun.", now it's no delay as it was before
/:cl:
****
- [x] Проверено на локалке
