### PR TITLE
fix: scream emote is usable again

### DIFF
--- a/modular_nova/modules/emotes/code/scream_emote.dm
+++ b/modular_nova/modules/emotes/code/scream_emote.dm
@@ -1,6 +1,6 @@
 /datum/emote/living/scream
 	vary = TRUE
-	mob_type_blacklist_typecache = list(/mob/living/carbon/human, /mob/living/basic/slime, /mob/living/brain) //Humans get specialized scream.
+	// SS1984 REMOVAL, non modular so upstream most likely will fix and override it as well: mob_type_blacklist_typecache = list(/mob/living/carbon/human, /mob/living/basic/slime, /mob/living/brain) //Humans get specialized scream.
 
 /datum/emote/living/scream/get_sound(mob/living/user)
 	if(issilicon(user))

--- a/modular_nova/modules/emotes/code/scream_emote.dm
+++ b/modular_nova/modules/emotes/code/scream_emote.dm
@@ -18,6 +18,7 @@
 		return 'sound/mobs/non-humanoids/gorilla/gorilla.ogg'
 	if(isalien(user))
 		return 'sound/mobs/non-humanoids/hiss/hiss6.ogg'
+	return ..() // SS1984 ADDITION
 
 /datum/emote/living/scream/can_run_emote(mob/living/user, status_check, intentional, params)
 	if(iscyborg(user))


### PR DESCRIPTION
Тг убрали дубликат, Нова модульно не убрала блеклист, со звуком тоже самое
можно было бы и модульно, но скорее всего Нова потом тоже исправит и перезапишет (так и надо в этом случае)

## Changelog

:cl:
fix: scream emote is usable again
/:cl:

****
- [x] Проверено на локалке