### PR TITLE
balance: new traits to station centcom

### DIFF
--- a/modular_ss220/modules/rolesedit/code/jobs/blueshield.dm
+++ b/modular_ss220/modules/rolesedit/code/jobs/blueshield.dm
@@ -234,6 +234,8 @@
 		/datum/job_department/central_command,
 		/datum/job_department/command,
 	)
+	mind_traits = list(SECURITY_MIND_TRAITS, TRAIT_FAST_TYING)
+	voice_of_god_power = 1.2 //Technically a private screamer, "Make way for the captain!"
 	liver_traits = list(TRAIT_PRETENDER_ROYAL_METABOLISM)
 
 	family_heirlooms = list(/obj/item/bedsheet/captain, /obj/item/clothing/head/beret/blueshield)

--- a/modular_ss220/modules/rolesedit/code/jobs/ntr.dm
+++ b/modular_ss220/modules/rolesedit/code/jobs/ntr.dm
@@ -44,7 +44,7 @@
 
 	nova_stars_only = FALSE //ss1984 edit original TRUE
 	job_flags = STATION_JOB_FLAGS | HEAD_OF_STAFF_JOB_FLAGS
-	mind_traits = list(HEAD_OF_STAFF_MIND_TRAITS)
+	mind_traits = list(HEAD_OF_STAFF_MIND_TRAITS, TRAIT_DESENSITIZED)
 	liver_traits = list(TRAIT_ROYAL_METABOLISM)
 	voice_of_god_power = 1.4 //Command staff has authority
 


### PR DESCRIPTION
## Описание
Бщ и нтр теперь обладают новыми трейтами что уменьшают дебафф настроения при чьей либо смерти.
Бщ теперь обладает множителем к силе бога (связки колосса) 1,2 так же как у ассистента мостика (у глав 1,4)


## Changelog

:cl:
balance: Blueshield and NTR recieved new DESENSITIZED trait (decreases mood penalty for someones death)
balance: Added voice of god power = 1.2 to blueshield (Like bridge assistant)
/:cl:

- [x] Проверено на локалке