### PR TITLE
fix: min_enemies now properly checks enemy roles

### DIFF
--- a/modular_ss220/modules/dynamic_tweaks/dynamic_ruleset.dm
+++ b/modular_ss220/modules/dynamic_tweaks/dynamic_ruleset.dm
@@ -122,7 +122,7 @@
 			continue
 		if (!human_mob.mind || !human_mob.mind.assigned_role)
 			continue
-		if (!("[human_mob.mind.assigned_role.type]" in enemy_roles))
+		if (!("[human_mob.mind.assigned_role.title]" in enemy_roles))
 			continue
 		valid_enemy += human_mob
 	return valid_enemy


### PR DESCRIPTION
## Changelog

:cl:
fix: Dynamic now properly checks enemy roles (before it was not selecting any ruleset that required enemies due to error)
/:cl:

****
- [x] Проверено на локалке
