### PR TITLE
fix: partial paper markup fix

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -672,7 +672,8 @@
 
 			playsound(src, SFX_WRITING_PEN, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE, SOUND_FALLOFF_EXPONENT + 3, ignore_walls = FALSE)
 
-			add_raw_text(paper_input, writing_implement_data["font"], writing_implement_data["color"], writing_implement_data["use_bold"], check_rights_for(user?.client, R_FUN))
+			var/parsed_input = parsemarkdown(paper_input, user) // SS1984 ADDITION
+			add_raw_text(parsed_input, writing_implement_data["font"], writing_implement_data["color"], writing_implement_data["use_bold"], check_rights_for(user?.client, R_FUN)) // SS1984 EDIT, original: add_raw_text(paper_input, writing_implement_data["font"], writing_implement_data["color"], writing_implement_data["use_bold"], check_rights_for(user?.client, R_FUN))
 
 			log_paper("[key_name(user)] wrote to [name]: \"[paper_input]\"")
 			to_chat(user, "You have added to your paper masterpiece!");


### PR DESCRIPTION
## Changelog

:cl:
fix: Experimental-partial fix papers markup, now %s works and some other markups as well (%f not work properly though)
/:cl:

****
- [x] Проверено на локалке
