### PR TITLE
qol: unbound by default duplicate hotkeys for switch hands

### DIFF
--- a/modular_ss220/modules/qol_casual_1984/hotkeys_unbound/mob.dm
+++ b/modular_ss220/modules/qol_casual_1984/hotkeys_unbound/mob.dm
@@ -1,0 +1,6 @@
+// that hotkeys are already bound to quick equip or drop, so it's causing weird behaviour sometimes, if someone need those - they can bind it anyway
+/datum/keybinding/mob/select_hand/right
+	hotkey_keys = list("Unbound")
+
+/datum/keybinding/mob/select_hand/left
+	hotkey_keys = list("Unbound")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9614,6 +9614,7 @@
 #include "modular_ss220\modules\qol_casual_1984\extended_perk_description\species.dm"
 #include "modular_ss220\modules\qol_casual_1984\healthanalzer_ui\health_analyzer.dm"
 #include "modular_ss220\modules\qol_casual_1984\tier2_tools_belt_ce\belt.dm"
+#include "modular_ss220\modules\qol_casual_1984\hotkeys_unbound\mob.dm"
 #include "modular_ss220\modules\ghostroles_stuff\ds2_interdyne_shared\techweb_types.dm"
 #include "modular_ss220\modules\ghostroles_stuff\ds2_interdyne_shared\machine_circuits.dm"
 #include "modular_ss220\modules\ghostroles_stuff\ds2_interdyne_shared\interdyne_ds2_rnd.dm"


### PR DESCRIPTION
## Changelog

:cl:
qol: Duplicate hotkeys for swap hands is unbound by default now (they were binded to Q that is also drop, and E that is quick equip), you still can bind them manually if need. Does not affect your current saved keybinding preferences (will work only if you reset all keybindings or new player).
/:cl:

****
- [x] Проверено на локалке
