### PR TITLE
admin: delay round end requires R_SERVER now

### DIFF
--- a/code/modules/admin/verbs/server.dm
+++ b/code/modules/admin/verbs/server.dm
@@ -126,7 +126,7 @@ ADMIN_VERB(start_now, R_SERVER, "Start Now", "Start the round RIGHT NOW.", ADMIN
 		message_admins("The server is still setting up, but the round will be started as soon as possible.")
 	BLACKBOX_LOG_ADMIN_VERB("Start Now")
 
-ADMIN_VERB(delay_round_end, R_ADMIN, "Delay Round End", "Prevent the server from restarting.", ADMIN_CATEGORY_SERVER) // NOVA EDIT CHANGE - Admins can delay the round end - ORIGINAL: ADMIN_VERB(delay_round_end, R_SERVER, "Delay Round End", "Prevent the server from restarting.", ADMIN_CATEGORY_SERVER)
+ADMIN_VERB(delay_round_end, R_SERVER, "Delay Round End", "Prevent the server from restarting.", ADMIN_CATEGORY_SERVER) // SS1984 REVERT OF NOVA'S CHARGE OF R_SERVER
 	if(SSticker.delay_end)
 		tgui_alert(user, "The round end is already delayed. The reason for the current delay is: \"[SSticker.admin_delay_notice]\"", "Alert", list("Ok"))
 		return


### PR DESCRIPTION
Для рестарта раунда не имея флага на рестарт (Триал Админ например), но имея флаг R_ADMIN, можно начать воут на рестарт:

<img width="623" height="38" alt="image" src="https://github.com/user-attachments/assets/088e5849-1bcb-4c7c-ae4e-5dc5ba7a8aa5" />
<img width="485" height="553" alt="image" src="https://github.com/user-attachments/assets/84d06f20-b5b7-4c74-9b1e-e1a11f6a705f" />

Это не будет работать, если раунд еще не начался, но сработает сразу после начала раунда

## Changelog

:cl:
admin: Delay Round End now required +R_SERVER flag (Trial admins no longer can delay round end, however they still can start vote for restart)
/:cl:

****
- [x] Проверено на локалке
