### PR TITLE
fix: firefly hollow point sprite

### DIFF
--- a/modular_ss220/modules/return_prs/sec_haul/code/firefly.dm
+++ b/modular_ss220/modules/return_prs/sec_haul/code/firefly.dm
@@ -37,7 +37,7 @@
 	icon_state = "pdh_lethal"
 
 /obj/item/ammo_box/magazine/multi_sprite/firefly/hp
-	icon_state = "pdh-hp"
+	icon_state = "pdh_hp"
 	ammo_type = /obj/item/ammo_casing/c9mm/hp
 
 /obj/item/ammo_box/magazine/multi_sprite/firefly/rubber


### PR DESCRIPTION
## Changelog

:cl:
fix: Firefly hollow-point ammo is now visible (added missing sprite)
/:cl:

****
- [x] Проверено на локалке
