### PR TITLE
balance: c38 caliber damage reduced back to TG

### DIFF
--- a/modular_ss220/modules/balance-1984/normal_c38_damage/projectiles.dm
+++ b/modular_ss220/modules/balance-1984/normal_c38_damage/projectiles.dm
@@ -1,0 +1,28 @@
+// Basically, just resets to former TG values (after nova's overrides we define our values, that are same as old TG values)
+
+/obj/projectile/bullet/c38
+	damage = 25
+	wound_bonus = -20
+
+/obj/projectile/bullet/c38/match/bouncy
+	damage = 10
+	stamina = 30
+
+/obj/projectile/bullet/c38/match/true
+	damage = 15
+
+/obj/projectile/bullet/c38/dumdum
+	damage = 15
+	embed_falloff_tile = -15
+
+/datum/embedding/bullet/c38/dumdum
+	embed_chance = 75
+
+/obj/projectile/bullet/c38/hotshot
+	damage = 20
+
+/obj/projectile/bullet/c38/iceblox
+	damage = 20
+
+/obj/projectile/bullet/c38/haywire
+	damage = 20

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9546,6 +9546,7 @@
 #include "modular_ss220\modules\balance-1984\advanced_egun_taser\energy_gun.dm"
 #include "modular_ss220\modules\balance-1984\no_ion_delay\special.dm"
 #include "modular_ss220\modules\balance-1984\electrocute_cooldown\living_defense.dm"
+#include "modular_ss220\modules\balance-1984\normal_c38_damage\projectiles.dm"
 #include "modular_ss220\modules\sol_pistol_incapacitator\magazines.dm"
 #include "modular_ss220\modules\sol_pistol_incapacitator\pistol.dm"
 #include "modular_ss220\modules\security_vouchers\code\closets\secure\security.dm"


### PR DESCRIPTION
## Changelog

:cl:
balance: c38 caliber damage&values is back to old TG values (they used primary in detective revolver and BR38)
/:cl:

****
- [x] Проверено на локалке