### PR TITLE
fix: borers fixes and small tweaks

### DIFF
--- a/config/dynamic.toml
+++ b/config/dynamic.toml
@@ -487,9 +487,8 @@ minimum_required_age = 0
 min_enemies = 1
 
 ["Cortical Borers"]
-# weight = 3
-weight = 0 # until fixed
-min_pop = 1
+weight = 3
+min_pop = 5
 blacklisted_roles = []
 min_antag_cap = 1
 # max_antag_cap = min_antag_cap

--- a/modular_nova/modules/cortical_borer/code/cortical_borer.dm
+++ b/modular_nova/modules/cortical_borer/code/cortical_borer.dm
@@ -220,9 +220,11 @@ GLOBAL_LIST_EMPTY(cortical_borers)
 	)
 	ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT) //they need to be able to move around
 
-	var/matrix/borer_matrix = matrix(transform)
-	borer_matrix.Scale(0.5, 0.5)
-	transform = borer_matrix
+	// SS1984 REMOVAL START
+	// var/matrix/borer_matrix = matrix(transform)
+	// borer_matrix.Scale(0.5, 0.5)
+	// transform = borer_matrix
+	// SS1984 REMOVAL END
 
 	name = "[initial(name)] ([generation]-[rand(100,999)])" //so their gen and a random. ex 1-288 is first gen named 288, 4-483 if fourth gen named 483
 

--- a/modular_nova/modules/cortical_borer/code/cortical_borer_antag.dm
+++ b/modular_nova/modules/cortical_borer/code/cortical_borer_antag.dm
@@ -98,7 +98,7 @@
 	min_pop = 50
 	repeatable = TRUE
 	/// List of on-station vents
-	var/list/vents = list()
+	// SS1984 REMOVAL var/list/vents = list()
 
 // Ripped from xenomorph ruleset
 /datum/dynamic_ruleset/midround/from_ghosts/cortical_borer/proc/find_vents()

--- a/modular_nova/modules/cortical_borer/code/cortical_borer_antag.dm
+++ b/modular_nova/modules/cortical_borer/code/cortical_borer_antag.dm
@@ -98,7 +98,7 @@
 	min_pop = 50
 	repeatable = TRUE
 	/// List of on-station vents
-	// SS1984 REMOVAL var/list/vents = list()
+	// SS1984 REMOVAL, also its possible would be harddel issue var/list/vents = list()
 
 // Ripped from xenomorph ruleset
 /datum/dynamic_ruleset/midround/from_ghosts/cortical_borer/proc/find_vents()

--- a/modular_ss220/modules/borers/cortical_borer.dm
+++ b/modular_ss220/modules/borers/cortical_borer.dm
@@ -1,0 +1,43 @@
+/datum/antagonist/cortical_borer/on_gain()
+	. = ..()
+	forge_objectives()
+
+/datum/antagonist/cortical_borer/forge_objectives()
+	var/datum/objective/borer_egg/objective_1 = new
+	var/datum/objective/borer_hosts/objective_2 = new
+	var/datum/objective/borer_blood/objective_3 = new
+
+	objective_1.owner = owner
+	objective_2.owner = owner
+	objective_3.owner = owner
+
+	objectives += objective_1
+	objectives += objective_2
+	objectives += objective_3
+
+// eggs
+/datum/objective/borer_egg
+
+/datum/objective/borer_egg/New()
+	explanation_text = "[GLOB.objective_egg_borer_number] borers producing [GLOB.objective_egg_egg_number] eggs: [GLOB.successful_egg_number]/[GLOB.objective_egg_borer_number]"
+
+/datum/objective/borer_egg/check_completion()
+	return GLOB.successful_egg_number >= GLOB.objective_egg_borer_number
+
+// hosts
+/datum/objective/borer_hosts
+
+/datum/objective/borer_hosts/New()
+	explanation_text = "[GLOB.objective_willing_hosts] willing hosts: [length(GLOB.willing_hosts)]/[GLOB.objective_willing_hosts]"
+
+/datum/objective/borer_hosts/check_completion()
+	return length(GLOB.willing_hosts) >= GLOB.objective_willing_hosts
+
+// blood
+/datum/objective/borer_blood
+
+/datum/objective/borer_blood/New()
+	explanation_text = "[GLOB.objective_blood_borer] borers learning [GLOB.objective_blood_chem] chemicals from the blood: [GLOB.successful_blood_chem]/[GLOB.objective_blood_borer]"
+
+/datum/objective/borer_blood/check_completion()
+	return GLOB.successful_blood_chem >= GLOB.objective_blood_borer

--- a/modular_ss220/modules/borers/cortical_borer.dm
+++ b/modular_ss220/modules/borers/cortical_borer.dm
@@ -2,6 +2,10 @@
 	. = ..()
 	forge_objectives()
 
+/datum/antagonist/cortical_borer/greet()
+	. = ..()
+	owner.announce_objectives()
+
 /datum/antagonist/cortical_borer/forge_objectives()
 	var/datum/objective/borer_egg/objective_1 = new
 	var/datum/objective/borer_hosts/objective_2 = new

--- a/modular_ss220/modules/borers/cortical_borer.dm
+++ b/modular_ss220/modules/borers/cortical_borer.dm
@@ -1,6 +1,6 @@
 /datum/antagonist/cortical_borer/on_gain()
-	. = ..()
 	forge_objectives()
+	return ..()
 
 /datum/antagonist/cortical_borer/greet()
 	. = ..()

--- a/modular_ss220/modules/borers/cortical_borer_antag.dm
+++ b/modular_ss220/modules/borers/cortical_borer_antag.dm
@@ -12,9 +12,29 @@
 	max_antag_cap = 3
 	min_antag_cap = 1
 	repeatable_weight_decrease = 3
+	var/datum/weakref/first_vent_ref // harddel paranoid
 
 /datum/dynamic_ruleset/midround/from_ghosts/cortical_borer/can_be_selected()
-	return ..() && length(find_vents()) > 0
+	if (!..())
+		return FALSE
+
+	var/list/vent_list = find_vents()
+	if (!vent_list || length(vent_list) < 1)
+		return FALSE
+
+	first_vent_ref = WEAKREF(vent_list[1])
+	return TRUE
+
+/datum/dynamic_ruleset/midround/from_ghosts/cortical_borer/create_ruleset_body()
+	var/loc_to_place
+	if (first_vent_ref)
+		var/obj/machinery/atmospherics/components/unary/vent_pump = first_vent_ref.resolve()
+		if (vent_pump)
+			loc_to_place = vent_pump.loc
+	else
+		first_vent_ref = null
+
+	return new /mob/living/basic/cortical_borer(loc_to_place) // so we place them temporaly here before to avoid runtimes related to nullspace
 
 /datum/dynamic_ruleset/midround/from_ghosts/cortical_borer/execute()
 	. = ..()

--- a/modular_ss220/modules/borers/cortical_borer_antag.dm
+++ b/modular_ss220/modules/borers/cortical_borer_antag.dm
@@ -1,0 +1,27 @@
+/datum/dynamic_ruleset/midround/from_ghosts/cortical_borer
+	signup_atom_appearance = /mob/living/basic/cortical_borer
+	false_alarm_able = TRUE
+	ruleset_flags = RULESET_INVADER
+	weight = list(
+		DYNAMIC_TIER_LOW = 3,
+		DYNAMIC_TIER_LOWMEDIUM = 2,
+		DYNAMIC_TIER_MEDIUMHIGH = 1,
+		DYNAMIC_TIER_HIGH = 1,
+	)
+	min_pop = 5
+	max_antag_cap = 3
+	min_antag_cap = 1
+	repeatable_weight_decrease = 3
+
+/datum/dynamic_ruleset/midround/from_ghosts/cortical_borer/can_be_selected()
+	return ..() && length(find_vents()) > 0
+
+/datum/dynamic_ruleset/midround/from_ghosts/cortical_borer/execute()
+	. = ..()
+	addtimer(CALLBACK(src, PROC_REF(announce_borers)), rand(375, 600) SECONDS)
+
+/datum/dynamic_ruleset/midround/from_ghosts/cortical_borer/proc/announce_borers()
+	priority_announce("Unidentified lifesigns detected coming aboard [station_name()]. Secure any exterior access, including ducting and ventilation.", "Lifesign Alert", ANNOUNCER_ALIENS)
+
+/datum/dynamic_ruleset/midround/from_ghosts/cortical_borer/false_alarm()
+	announce_borers()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9695,4 +9695,5 @@
 #include "modular_ss220\modules\nanomaps\crew_monitor.dm"
 #include "modular_ss220\modules\nanomaps\nanomap_assets.dm"
 #include "modular_ss220\modules\nanomaps\nanomap_datum.dm"
+#include "modular_ss220\modules\borers\cortical_borer_antag.dm"
 // END_INCLUDE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9695,5 +9695,6 @@
 #include "modular_ss220\modules\nanomaps\crew_monitor.dm"
 #include "modular_ss220\modules\nanomaps\nanomap_assets.dm"
 #include "modular_ss220\modules\nanomaps\nanomap_datum.dm"
+#include "modular_ss220\modules\borers\cortical_borer.dm"
 #include "modular_ss220\modules\borers\cortical_borer_antag.dm"
 // END_INCLUDE


### PR DESCRIPTION
## Changelog

:cl:
balance: Borers scale 0.5 => 1.0
qol: Borers objectives are also shown in TGUI now
fix: Borers spawn from dynamic event fixed (they still legacy antag and not 100% tested now)
config: Borers enabled to be spawned again in dynamic (weight 3, min pop = 5, does not require security). Borers are some kind "RP" antag for now, as they cannot directly control host (and cannot inhabit monkey)
/:cl:

****
- [x] Проверено на локалке
