### PR TITLE
balance: maximum 1 shell by drone dispenser & higher cooldown

### DIFF
--- a/modular_ss220/modules/balance-1984/drones_restrictions/drone_dispenser.dm
+++ b/modular_ss220/modules/balance-1984/drones_restrictions/drone_dispenser.dm
@@ -1,0 +1,3 @@
+/obj/machinery/drone_dispenser
+	cooldownTime = 5 MINUTES
+	maximum_idle = 1

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9551,6 +9551,7 @@
 #include "modular_ss220\modules\balance-1984\normal_c38_damage\projectiles.dm"
 #include "modular_ss220\modules\balance-1984\battlerifle_tg\automatic.dm"
 #include "modular_ss220\modules\balance-1984\max_staminadamage_tg\living_defines.dm"
+#include "modular_ss220\modules\balance-1984\drones_restrictions\drone_dispenser.dm"
 #include "modular_ss220\modules\sol_pistol_incapacitator\magazines.dm"
 #include "modular_ss220\modules\sol_pistol_incapacitator\pistol.dm"
 #include "modular_ss220\modules\security_vouchers\code\closets\secure\security.dm"


### PR DESCRIPTION
## Changelog

:cl:
balance: Drone dispenser (station) now produces 3 => 1 in-active shells
balance: Drone dispenser (station) cooldown 3 minutes => 5 minutes
/:cl:

****
- [x] Проверено на локалке
