### PR TITLE
del: Revert Nova's allstar weapon sprites

### DIFF
--- a/modular_nova/modules/aesthetics/guns/code/energy.dm
+++ b/modular_nova/modules/aesthetics/guns/code/energy.dm
@@ -1,3 +1,4 @@
+/* SS1984 REMOVAL START
 /obj/item/gun/energy/ionrifle
 	icon = 'modular_nova/modules/aesthetics/guns/icons/energy.dmi'
 	// also covers the ion carbine
@@ -68,3 +69,4 @@
 	worn_icon_state = "gun"
 	worn_icon = null
 	shaded_charge = FALSE
+SS1984 REMOVAL END */

--- a/modular_ss220/modules/balance-1984/old_hos_gun/energy.dm
+++ b/modular_ss220/modules/balance-1984/old_hos_gun/energy.dm
@@ -1,0 +1,8 @@
+/obj/item/ammo_casing/energy/laser/hos
+	e_cost = LASER_SHOTS(12, STANDARD_CELL_CHARGE * 1.2)
+
+/obj/item/ammo_casing/energy/disabler/hos
+	e_cost = LASER_SHOTS(20, STANDARD_CELL_CHARGE * 1.2)
+
+/obj/item/ammo_casing/energy/ion/hos
+	e_cost = LASER_SHOTS(4, STANDARD_CELL_CHARGE * 1.2)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9572,6 +9572,7 @@
 #include "modular_ss220\modules\balance-1984\battlerifle_tg\automatic.dm"
 #include "modular_ss220\modules\balance-1984\max_staminadamage_tg\living_defines.dm"
 #include "modular_ss220\modules\balance-1984\drones_restrictions\drone_dispenser.dm"
+#include "modular_ss220\modules\balance-1984\old_hos_gun\energy.dm"
 #include "modular_ss220\modules\sol_pistol_incapacitator\magazines.dm"
 #include "modular_ss220\modules\sol_pistol_incapacitator\pistol.dm"
 #include "modular_ss220\modules\security_vouchers\code\closets\secure\security.dm"


### PR DESCRIPTION
Пушку БЩ оставил как есть

## Скриншоты

<img width="510" height="240" alt="image" src="https://github.com/user-attachments/assets/8ec94210-dcb6-44be-a9cc-5fee0dbc84e3" />

## Changelog

:cl:
del: Revert "Allstar Lasers has updated a good chunk of their crew-attainable energy firearms with shiny new casings, as to unify their design philosophies or something."
balance: Revert "The X-01 multiphase energy gun (HoS egun) now has matching capacities for laser and disabler (25 shots, up from 12 for laser, 20 from disabler) and a slight increase in ion mode capacity (5 shots, up from 4)."
/:cl:

****
- [x] Проверено на локалке
