### PR TITLE
add: engineer skillchip built-in for ghostroles engineering roles

### DIFF
--- a/modular_ss220/modules/rolesedit/code/old_station/oldstation.dm
+++ b/modular_ss220/modules/rolesedit/code/old_station/oldstation.dm
@@ -300,6 +300,7 @@
 	gloves = /obj/item/clothing/gloves/color/fyellow/old
 	shoes = /obj/item/clothing/shoes/workboots
 	l_pocket = /obj/item/tank/internals/emergency_oxygen
+	skillchips = list(/obj/item/skillchip/job/engineer) // might be not really great lorewise (if chips weren't invented yet), but for gameplay it's good
 
 /datum/outfit/oldsci
 	name = "Ancient Scientist"

--- a/modular_ss220/modules/rolesedit/code/syndicate_roles/ds.dm
+++ b/modular_ss220/modules/rolesedit/code/syndicate_roles/ds.dm
@@ -117,6 +117,7 @@
 
 /datum/outfit/ds2/syndicate/enginetech
 	role_job = /datum/job/ds2/engineer
+	skillchips = list(/obj/item/skillchip/job/engineer)
 
 /datum/outfit/ds2/syndicate/researcher
 	role_job = /datum/job/ds2/science
@@ -126,7 +127,3 @@
 
 /datum/outfit/ds2/syndicate/brigoff
 	role_job = /datum/job/ds2/enforce
-
-/datum/outfit/ds2/syndicate/enginetech
-	role_job = /datum/job/ds2/engineer
-	skillchips = list(/obj/item/skillchip/job/engineer)

--- a/modular_ss220/modules/rolesedit/code/syndicate_roles/ds.dm
+++ b/modular_ss220/modules/rolesedit/code/syndicate_roles/ds.dm
@@ -126,3 +126,7 @@
 
 /datum/outfit/ds2/syndicate/brigoff
 	role_job = /datum/job/ds2/enforce
+
+/datum/outfit/ds2/syndicate/enginetech
+	role_job = /datum/job/ds2/engineer
+	skillchips = list(/obj/item/skillchip/job/engineer)

--- a/modular_ss220/modules/rolesedit/code/tarkon/tarkon.dm
+++ b/modular_ss220/modules/rolesedit/code/tarkon/tarkon.dm
@@ -41,6 +41,9 @@
 	id = /obj/item/card/id/advanced/tarkon/deck
 	role_job = /datum/job/tarkon
 
+/datum/outfit/tarkon/engi
+	skillchips = list(/obj/item/skillchip/job/engineer)
+
 /datum/outfit/tarkon/ensign
 	role_job = /datum/job/tarkon/command
 


### PR DESCRIPTION
## Changelog

:cl:
add: Ghost-roles engineering based roles now have engineering skillchip to see wires (DS2, Tarkon, Charlie Station)
/:cl:

****
- [x] Проверено на локалке
