### PR TITLE
qol: examining cell charger is now shows grid's charging availability

### DIFF
--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -34,6 +34,7 @@ NOVA EDIT END */
 		. += "Current charge: [round(charging.percent(), 1)]%."
 	if(in_range(user, src) || isobserver(user))
 		. += span_notice("The status display reads: Charging power: <b>[display_power(charge_rate, convert = FALSE)]</b>.")
+		. += get_powermonitoring_desc() // SS1984 ADDITION
 
 /obj/machinery/cell_charger/wrench_act(mob/living/user, obj/item/tool)
 	. = ..()

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -34,7 +34,7 @@ NOVA EDIT END */
 		. += "Current charge: [round(charging.percent(), 1)]%."
 	if(in_range(user, src) || isobserver(user))
 		. += span_notice("The status display reads: Charging power: <b>[display_power(charge_rate, convert = FALSE)]</b>.")
-		. += get_powermonitoring_desc() // SS1984 ADDITION
+		. += get_powermonitoring_desc(src) // SS1984 ADDITION
 
 /obj/machinery/cell_charger/wrench_act(mob/living/user, obj/item/tool)
 	. = ..()

--- a/modular_nova/modules/multicellcharger/code/multi_cell_charger.dm
+++ b/modular_nova/modules/multicellcharger/code/multi_cell_charger.dm
@@ -51,7 +51,7 @@
 			. += "There's [charging] cell in the charger, current charge: [round(charging.percent(), 1)]%."
 	if(in_range(user, src) || isobserver(user))
 		. += span_notice("The status display reads: Charging power: <b>[display_power(charge_rate, convert = FALSE)]</b> per cell.")
-		. += get_powermonitoring_desc() // SS1984 ADDITION
+		. += get_powermonitoring_desc(src) // SS1984 ADDITION
 	. += span_notice("Right click it to remove all the cells at once!")
 
 /obj/machinery/cell_charger_multi/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)

--- a/modular_nova/modules/multicellcharger/code/multi_cell_charger.dm
+++ b/modular_nova/modules/multicellcharger/code/multi_cell_charger.dm
@@ -51,6 +51,7 @@
 			. += "There's [charging] cell in the charger, current charge: [round(charging.percent(), 1)]%."
 	if(in_range(user, src) || isobserver(user))
 		. += span_notice("The status display reads: Charging power: <b>[display_power(charge_rate, convert = FALSE)]</b> per cell.")
+		. += get_powermonitoring_desc() // SS1984 ADDITION
 	. += span_notice("Right click it to remove all the cells at once!")
 
 /obj/machinery/cell_charger_multi/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)

--- a/modular_ss220/modules/qol_casual_1984/cellcharger_power_desc/cell_charger.dm
+++ b/modular_ss220/modules/qol_casual_1984/cellcharger_power_desc/cell_charger.dm
@@ -1,7 +1,7 @@
 #define POWERMONITORING_RED_TEXT span_notice("Power monitoring port is: [span_red("RED")], there is no surplus power in grid. <b>Can't charge cells</b>.")
 #define POWERMONITORING_GREEN_TEXT span_notice("Power monitoring port is: [span_green("GREEN")], there is a surplus power in grid. <b>Can charge cells</b>.")
 
-/obj/machinery/cell_charger/proc/get_powermonitoring_desc(mob/user)
+/obj/machinery/cell_charger/proc/get_powermonitoring_desc()
 	var/area/home = get_area(src)
 	if(isnull(home))
 		return POWERMONITORING_RED_TEXT

--- a/modular_ss220/modules/qol_casual_1984/cellcharger_power_desc/cell_charger.dm
+++ b/modular_ss220/modules/qol_casual_1984/cellcharger_power_desc/cell_charger.dm
@@ -1,0 +1,19 @@
+#define POWERMONITORING_RED_TEXT span_notice("Power monitoring port is: [span_red("RED")], there is no surplus power in grid. <b>Can't charge cells</b>.")
+#define POWERMONITORING_GREEN_TEXT span_notice("Power monitoring port is: [span_green("GREEN")], there is a surplus power in grid. <b>Can charge cells</b>.")
+
+/obj/machinery/cell_charger/proc/get_powermonitoring_desc(mob/user)
+	var/area/home = get_area(src)
+	if(isnull(home))
+		return POWERMONITORING_RED_TEXT
+	if(!home.requires_power)
+		return POWERMONITORING_GREEN_TEXT
+	var/obj/machinery/power/apc/local_apc = home.apc
+	if(isnull(local_apc) || !local_apc.operating)
+		return POWERMONITORING_RED_TEXT
+	var/surplus = local_apc.surplus()
+	if (surplus <= 0)
+		return POWERMONITORING_RED_TEXT
+	return POWERMONITORING_GREEN_TEXT
+
+#undef POWERMONITORING_RED_TEXT
+#undef POWERMONITORING_GREEN_TEXT

--- a/modular_ss220/modules/qol_casual_1984/cellcharger_power_desc/cell_charger.dm
+++ b/modular_ss220/modules/qol_casual_1984/cellcharger_power_desc/cell_charger.dm
@@ -1,8 +1,8 @@
 #define POWERMONITORING_RED_TEXT span_notice("Power monitoring port is: [span_red("RED")], there is no surplus power in grid. <b>Can't charge cells</b>.")
 #define POWERMONITORING_GREEN_TEXT span_notice("Power monitoring port is: [span_green("GREEN")], there is a surplus power in grid. <b>Can charge cells</b>.")
 
-/obj/machinery/cell_charger/proc/get_powermonitoring_desc()
-	var/area/home = get_area(src)
+/proc/get_powermonitoring_desc(obj/machinery/relative_charger)
+	var/area/home = get_area(relative_charger)
 	if(isnull(home))
 		return POWERMONITORING_RED_TEXT
 	if(!home.requires_power)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9678,6 +9678,7 @@
 #include "modular_ss220\modules\qol_casual_1984\genders_for_species\plasmamen.dm"
 #include "modular_ss220\modules\qol_casual_1984\genders_for_species\ghost.dm"
 #include "modular_ss220\modules\qol_casual_1984\whetstone_vendor\drinnerware.dm"
+#include "modular_ss220\modules\qol_casual_1984\cellcharger_power_desc\cell_charger.dm"
 #include "modular_ss220\modules\ghostroles_stuff\ds2_interdyne_shared\techweb_types.dm"
 #include "modular_ss220\modules\ghostroles_stuff\ds2_interdyne_shared\machine_circuits.dm"
 #include "modular_ss220\modules\ghostroles_stuff\ds2_interdyne_shared\interdyne_ds2_rnd.dm"


### PR DESCRIPTION
## Скриншоты

### Есть излишки в подключенной к АПЦ сети

<img width="1279" height="568" alt="image" src="https://github.com/user-attachments/assets/f5aaefdd-bc13-4ed6-9dca-7c7b45c13e2c" />

### Нет излишков в подключенной к АПЦ сети

<img width="1312" height="611" alt="image" src="https://github.com/user-attachments/assets/f131c428-d603-4e12-a3c9-9d3407c9ad33" />

## Changelog

:cl:
qol: Examining cell charger now shows grid's charging availability description. So if cell charger won't charge cells, it will display info related to that.
/:cl:

****
- [x] Проверено на локалке
