### PR TITLE
fix: trim accesses are shown again in computer

### DIFF
--- a/tgui/packages/tgui/interfaces/NtosCard.tsx
+++ b/tgui/packages/tgui/interfaces/NtosCard.tsx
@@ -123,7 +123,7 @@ export const NtosCardContent = (props) => {
                 selectedList={modified_card.access_on_card}
                 wildcardFlags={wildcard_flags}
                 wildcardSlots={modified_card.wildcard_slots}
-                trim_access={modified_card.trim_access}
+                trimAccess={modified_card.trim_access} // SS1984 EDIT, original: trim_access={modified_card.trim_access}
                 accessFlags={access_flags}
                 accessFlagNames={access_flag_names}
                 showBasic={!!show_basic}


### PR DESCRIPTION
## Changelog

:cl:
fix: Trim Access is properly shown at ID computer again
/:cl:

****
- [x] Проверено на локалке