### PR TITLE
balance: oldstation skillchips edit

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldstation1984.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation1984.dmm
@@ -953,7 +953,9 @@
 /obj/item/clothing/head/utility/hardhat/welding,
 /obj/item/clothing/gloves/tinkerer,
 /obj/item/clothing/gloves/atmos,
-/obj/item/skillchip/job/engineer,
+/obj/item/skillchip/job/engineer{
+	desc = "Endorsed by Nanotrasen Navy Chief Engineer."
+	},
 /turf/open/floor/plating,
 /area/ruin/space/ancientstation/beta/supermatter)
 "ed" = (
@@ -4457,6 +4459,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/decal/remains/human,
+/obj/item/skillchip/job/engineer{
+	name = "Prototype Engineering C1-RCU-1T skillchip";
+	skill_name = "Engineering Circuitry Beta";
+	desc = "Endorsed by Nanotrasen Navy Chief Engineer."
+	},
 /turf/open/floor/engine/airless,
 /area/ruin/space/ancientstation/beta/supermatter)
 "wo" = (

--- a/_maps/RandomRuins/SpaceRuins/oldstation1984.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation1984.dmm
@@ -954,6 +954,8 @@
 /obj/item/clothing/gloves/tinkerer,
 /obj/item/clothing/gloves/atmos,
 /obj/item/skillchip/job/engineer{
+	name = "Prototype Engineering C1-RCU-1T skillchip";
+	skill_name = "Engineering Circuitry Beta";
 	desc = "Endorsed by Nanotrasen Navy Chief Engineer."
 	},
 /turf/open/floor/plating,

--- a/_maps/RandomRuins/SpaceRuins/oldstation1984.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation1984.dmm
@@ -953,11 +953,7 @@
 /obj/item/clothing/head/utility/hardhat/welding,
 /obj/item/clothing/gloves/tinkerer,
 /obj/item/clothing/gloves/atmos,
-/obj/item/skillchip/job/engineer{
-	name = "Prototype Engineering C1-RCU-1T skillchip";
-	skill_name = "Engineering Circuitry Beta";
-	desc = "Endorsed by Nanotrasen Navy Chief Engineer."
-	},
+/obj/item/skillchip/job/oldstation/engineering,
 /turf/open/floor/plating,
 /area/ruin/space/ancientstation/beta/supermatter)
 "ed" = (

--- a/_maps/RandomRuins/SpaceRuins/oldstation1984.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation1984.dmm
@@ -5403,6 +5403,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/safe/floor/charlie_captain,
+/obj/item/blueprints/oldstation,
 /obj/item/card/id/away/old/captains_spare,
 /obj/item/clothing/suit/space/nasavoid/captain,
 /obj/item/clothing/head/helmet/space/nasavoid/captain,

--- a/_maps/RandomRuins/SpaceRuins/oldstation1984.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation1984.dmm
@@ -4461,11 +4461,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/decal/remains/human,
-/obj/item/skillchip/job/engineer{
-	name = "Prototype Engineering C1-RCU-1T skillchip";
-	skill_name = "Engineering Circuitry Beta";
-	desc = "Endorsed by Nanotrasen Navy Chief Engineer."
-	},
 /turf/open/floor/engine/airless,
 /area/ruin/space/ancientstation/beta/supermatter)
 "wo" = (

--- a/_maps/RandomRuins/SpaceRuins/oldstation1984.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation1984.dmm
@@ -8138,7 +8138,7 @@
 "Up" = (
 /obj/structure/closet/crate/medical,
 /obj/item/circuitboard/machine/sleeper,
-/obj/item/skillchip/job/psychology,
+/obj/item/skillchip/job/oldstation/medical,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ancientstation/beta/medbay)
 "Uq" = (

--- a/modular_ss220/modules/rolesedit/code/old_station/oldstation.dm
+++ b/modular_ss220/modules/rolesedit/code/old_station/oldstation.dm
@@ -438,13 +438,34 @@
 
 //blueprints
 
+#define LEGEND_VIEWING_LIST "watching_list"
+///The blueprints are on the main page.
+#define LEGEND_OFF "off"
+
 /obj/item/blueprints/oldstation
 	name = "A.B.C.D stations blueprints"
 	desc = "Blueprints of the complex of stations. There is a \"Nanotrasen Navy - Classified\" stamp and some old coffee stains on it."
+	fluffnotice = "Property of Nanotrasen Navy. For heads of staff or engineering personnel only. Store in high-secure storage."
 
+/obj/item/blueprints/oldstation/ui_static_data(mob/user)
+	var/list/data = list()
+	data["legend_viewing_list"] = LEGEND_VIEWING_LIST
+	data["legend_off"] = LEGEND_OFF
+	data["fluff_notice"] = fluffnotice
+	data["station_name"] = "Nanotrasen Station Complex - Alpha, Beta, Charlie, Delta."
+	data["wire_devices"] = list()
+	for(var/wireset in GLOB.wire_color_directory)
+		data["wire_devices"] += list(list(
+			"name" = GLOB.wire_name_directory[wireset],
+			"ref" = wireset,
+		))
+	return data
 
 /obj/item/blueprints/oldstation/eng
 	name = "Crude copy of A.B.C.D stations blueprints"
-	desc = "Small crude copy of stations complex blueprints. It contain information about some wires, that are likely to help in the maintenance of the airlock and other electronic devices."
+	desc = "Small crude copy of stations complex blueprints. It contain information about some wires, that are likely to help in the maintenance of the airlocks and other electronic devices."
 	icon_state = "shuttle_blueprints_crude1"
 	w_class = WEIGHT_CLASS_SMALL
+
+#undef LEGEND_VIEWING_LIST
+#undef LEGEND_OFF

--- a/modular_ss220/modules/rolesedit/code/old_station/oldstation.dm
+++ b/modular_ss220/modules/rolesedit/code/old_station/oldstation.dm
@@ -433,6 +433,29 @@
 	activate_message = span_notice("You suddenly comprehend the secrets behind airlock and APC circuitry and your pain recentors in hands seems less sensetive to hot objects.")
 	deactivate_message = span_notice("Airlock and APC circuitry stops making sense as images of coloured wires fade from your mind... And you feel like hot objects could stop you again...")
 
+/obj/item/skillchip/job/oldstation/medical
+	name = "Prototype Medical SRX-4H912T skillchip"
+	desc = "A skillchip containing 'new' Nanotrasen medical training protocols, boosting overall medical efficiency. Endorsed by the Nanotrasen Navy Security and Medical ERTs."
+	auto_traits = list(TRAIT_MADNESS_IMMUNE, TRAIT_ENTRAILS_READER, TRAIT_SELF_SURGERY)
+	skill_name = "Medic++"
+	skill_description = "Become a real field doctor in an instant!"
+	skill_icon = FA_ICON_USER_DOCTOR
+	activate_message = span_notice("You realize that your surgical skills have become noticeably better and also there's nothing stopping you from performing surgery on yourself.")
+	deactivate_message = span_notice("You suddenly feel like your medical skills are fading.")
+
+/obj/item/skillchip/job/oldstation/medical/on_activate(mob/living/carbon/user, silent)
+	. = ..()
+	RegisterSignal(user, COMSIG_LIVING_INITIATE_SURGERY_STEP, PROC_REF(apply_surgery_buff))
+
+/obj/item/skillchip/job/oldstation/medical/on_deactivate(mob/living/carbon/user, silent)
+	. = ..()
+	UnregisterSignal(user, COMSIG_LIVING_INITIATE_SURGERY_STEP)
+
+/obj/item/skillchip/job/oldstation/medical/proc/apply_surgery_buff(mob/living/carbon/_source, mob/living/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery, datum/surgery_step/step, list/modifiers)
+	SIGNAL_HANDLER
+	if(user != target)
+		modifiers[FAIL_PROB_INDEX] -= 10
+		modifiers[SPEED_MOD_INDEX] *= 0.9
 
 //blueprints
 #define LEGEND_VIEWING_LIST "watching_list"

--- a/modular_ss220/modules/rolesedit/code/old_station/oldstation.dm
+++ b/modular_ss220/modules/rolesedit/code/old_station/oldstation.dm
@@ -422,6 +422,7 @@
 	name = "Prototype skillchip"
 	desc = "Endorsed by the Nanotrasen Navy."
 	complexity = 2
+	abstract_parent_type = /obj/item/skillchip/job/oldstation
 
 /obj/item/skillchip/job/oldstation/engineering
 	name = "Prototype Engineering C0-RCU-1T-N11H5M2R1 skillchip"
@@ -442,6 +443,7 @@
 	skill_icon = FA_ICON_USER_DOCTOR
 	activate_message = span_notice("You realize that your surgical skills have become noticeably better and also there's nothing stopping you from performing surgery on yourself.")
 	deactivate_message = span_notice("You suddenly feel like your medical skills are fading.")
+	slot_use = 3
 
 /obj/item/skillchip/job/oldstation/medical/on_activate(mob/living/carbon/user, silent)
 	. = ..()

--- a/modular_ss220/modules/rolesedit/code/old_station/oldstation.dm
+++ b/modular_ss220/modules/rolesedit/code/old_station/oldstation.dm
@@ -418,12 +418,10 @@
 	icon_state = "sleeper-open"
 
 //skillchips
-
 /obj/item/skillchip/job/oldstation
 	name = "Prototype skillchip"
 	desc = "Endorsed by the Nanotrasen Navy."
 	complexity = 2
-
 
 /obj/item/skillchip/job/oldstation/engineering
 	name = "Prototype Engineering C0-RCU-1T-N11H5M2R1 skillchip"
@@ -437,7 +435,6 @@
 
 
 //blueprints
-
 #define LEGEND_VIEWING_LIST "watching_list"
 ///The blueprints are on the main page.
 #define LEGEND_OFF "off"

--- a/modular_ss220/modules/rolesedit/code/old_station/oldstation.dm
+++ b/modular_ss220/modules/rolesedit/code/old_station/oldstation.dm
@@ -300,6 +300,7 @@
 	gloves = /obj/item/clothing/gloves/color/fyellow/old
 	shoes = /obj/item/clothing/shoes/workboots
 	l_pocket = /obj/item/tank/internals/emergency_oxygen
+	r_pocket = /obj/item/blueprints/oldstation/eng
 
 /datum/outfit/oldsci
 	name = "Ancient Scientist"
@@ -415,3 +416,35 @@
 /obj/structure/showcase/machinery/oldpod/used
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper-open"
+
+//skillchips
+
+/obj/item/skillchip/job/oldstation
+	name = "Prototype skillchip"
+	desc = "Endorsed by the Nanotrasen Navy."
+	complexity = 2
+
+
+/obj/item/skillchip/job/oldstation/engineering
+	name = "Prototype Engineering C0-RCU-1T-N11H5M2R1 skillchip"
+	desc = "Endorsed by the Chief Engineer of the Nanotrasen Navy and the Head Janitor himself."
+	auto_traits = list(TRAIT_KNOW_ENGI_WIRES, TRAIT_LIGHTBULB_REMOVER)
+	skill_name = "Combined Engineering Circuitry / Lightbulb Removing skills Beta"
+	skill_description = "Recognise airlock and APC wire layouts and understand their functionality at a glance and also stop failing taking out lightbulbs, even without gloves!"
+	skill_icon = "sitemap"
+	activate_message = span_notice("You suddenly comprehend the secrets behind airlock and APC circuitry and your pain recentors in hands seems less sensetive to hot objects.")
+	deactivate_message = span_notice("Airlock and APC circuitry stops making sense as images of coloured wires fade from your mind... And you feel like hot objects could stop you again...")
+
+
+//blueprints
+
+/obj/item/blueprints/oldstation
+	name = "A.B.C.D stations blueprints"
+	desc = "Blueprints of the complex of stations. There is a \"Nanotrasen Navy - Classified\" stamp and some old coffee stains on it."
+
+
+/obj/item/blueprints/oldstation/eng
+	name = "Crude copy of A.B.C.D stations blueprints"
+	desc = "Small crude copy of stations complex blueprints. It contain information about some wires, that are likely to help in the maintenance of the airlock and other electronic devices."
+	icon_state = "shuttle_blueprints_crude1"
+	w_class = WEIGHT_CLASS_SMALL

--- a/modular_ss220/modules/rolesedit/code/old_station/oldstation.dm
+++ b/modular_ss220/modules/rolesedit/code/old_station/oldstation.dm
@@ -300,7 +300,6 @@
 	gloves = /obj/item/clothing/gloves/color/fyellow/old
 	shoes = /obj/item/clothing/shoes/workboots
 	l_pocket = /obj/item/tank/internals/emergency_oxygen
-	skillchips = list(/obj/item/skillchip/job/engineer) // might be not really great lorewise (if chips weren't invented yet), but for gameplay it's good
 
 /datum/outfit/oldsci
 	name = "Ancient Scientist"


### PR DESCRIPTION
## Описание
Убран скилл чип у лоадаута инженера старой станции
Изменено описание скиллчипа инженера в ящике на складе старой станции

## Changelog

:cl:
del: Removed eng skillchip from oldstation eng
add: Added small blueprints to oldstation engineer
map: Added blueprints to bridge safe
map: Replaced eng skillchip in oldstation eng storage with both light bulb removing/ know wires prototype
map: Replaced psychologist chip in oldstation med crate with custom combined chip (maddness immune, coroner organs examine, speed buff while operating other, ability to do operations on yourself-without buff)
/:cl:

- [x] Проверено на локалке