### PR TITLE
balance: TRAIT_NOSOFTCRIT no longer stun in softcrit + hulk until hardcrit

### DIFF
--- a/code/datums/mutations/hulk.dm
+++ b/code/datums/mutations/hulk.dm
@@ -63,7 +63,7 @@
 	source.say("WAAAAAAAAAAAAAAGH!", forced="hulk")
 
 /datum/mutation/hulk/on_life(seconds_per_tick, times_fired)
-	if(owner.health < owner.crit_threshold)
+	if(owner.health < owner.hardcrit_threshold) // SS1984 EDIT, original: if(owner.health < owner.crit_threshold)
 		on_losing(owner)
 		to_chat(owner, span_danger("You suddenly feel very weak."))
 		qdel(src)

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -682,7 +682,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	// SS1984 ADDITION START
 	if (H.stat == SOFT_CRIT)
 		H.adjust_stutter(1 SECONDS * seconds_per_tick) // should keep slutter always (almost, based on lags)
-		if (prob(3 * seconds_per_tick))
+		if (!HAS_TRAIT(H, TRAIT_NOSOFTCRIT) && prob(3 * seconds_per_tick))
 			H.Paralyze(4 SECONDS)
 	// SS1984 ADDITION END
 


### PR DESCRIPTION
## Changelog

:cl:
balance: Everything that gives TRAIT_NOSOFTCRIT (such as luxury medipens at mining, hulk mutation and all others sources) now makes you ignore random stun probability from being in soft crit
balance: Hulk mutation is losed on going hardcrit, instead of when going softcrit
/:cl:

****
- [x] Проверено на локалке
