### PR TITLE
fix: hulk is properly removed on death

### DIFF
--- a/modular_ss220/modules/upstream-fixes/hulk_loss_on_death/hulk.dm
+++ b/modular_ss220/modules/upstream-fixes/hulk_loss_on_death/hulk.dm
@@ -1,0 +1,16 @@
+/datum/mutation/hulk/on_acquiring(mob/living/carbon/human/owner)
+	. = ..()
+	if(!.)
+		return
+
+	RegisterSignal(owner, COMSIG_LIVING_DEATH, PROC_REF(on_death))
+
+/datum/mutation/hulk/on_losing(mob/living/carbon/human/owner)
+	if(..())
+		return
+
+	UnregisterSignal(owner, COMSIG_LIVING_DEATH)
+
+/datum/mutation/hulk/proc/on_death()
+	on_losing(owner)
+	qdel(src)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9591,6 +9591,7 @@
 #include "modular_ss220\modules\upstream-fixes\scarring_rejuve\human_helpers.dm"
 #include "modular_ss220\modules\upstream-fixes\aicontroller_ghostize\ai_controller.dm"
 #include "modular_ss220\modules\upstream-fixes\emotes_restrictions\emote.dm"
+#include "modular_ss220\modules\upstream-fixes\hulk_loss_on_death\hulk.dm"
 #include "modular_ss220\modules\vendors\code\dorms.dm"
 #include "modular_ss220\modules\restrict-species\restrict_species.dm"
 #include "modular_ss220\modules\disabled_station_traits\negative_traits.dm"


### PR DESCRIPTION
## Changelog

:cl:
fix: Hulk is now properly removed on death (in case it get one-shot somehow bypassing hardcrit)
/:cl:

****
- [x] Проверено на локалке
