### PR TITLE
qol: throw keybinding is R

### DIFF
--- a/modular_ss220/modules/paradise_keybindings/code/keybinding/living.dm
+++ b/modular_ss220/modules/paradise_keybindings/code/keybinding/living.dm
@@ -18,3 +18,6 @@
 
 /datum/keybinding/living/disable_combat_mode
 	hotkey_keys = list("1")
+
+/datum/keybinding/living/toggle_throw_mode
+	hotkey_keys = list("R")


### PR DESCRIPTION
## Changelog

:cl:
qol: Throw-mode keybinding by default is R now (applies only when you don't have overrides for it)
/:cl:

****
- [x] Проверено на локалке
