### PR TITLE
balance: hemophage heal nerf

### DIFF
--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_status_effects.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_status_effects.dm
@@ -9,9 +9,9 @@
 /// The threshold at which you have too much damage to use hemokinetic regen.
 #define DAMAGE_LIMIT_HEMOKINETIC_REGEN 50
 /// The amount in units of blood that gets consumed per point of damage healed (by hemokinetic regen and master of the house)
-#define HEMOKINETIC_REGEN_BLOOD_CONSUMPTION 0.25
+#define HEMOKINETIC_REGEN_BLOOD_CONSUMPTION 1 // SS1984 EDIT, original: #define HEMOKINETIC_REGEN_BLOOD_CONSUMPTION 0.25
 /// How much damage per second is healed by hemokinetic regen
-#define HEMOKINETIC_REGEN_HEALING 1.8
+#define HEMOKINETIC_REGEN_HEALING 0.5 // SS1984 EDIT, original: #define HEMOKINETIC_REGEN_HEALING 1.8
 
 /datum/status_effect/blood_thirst_satiated
 	id = "blood_thirst_satiated"


### PR DESCRIPTION
Посчитано с учетом формулы

```
	amount_healed += carbon_owner.adjustBruteLoss(-HEMOKINETIC_REGEN_HEALING * seconds_between_ticks, updating_health = FALSE, required_bodytype = BODYTYPE_ORGANIC)
	amount_healed += carbon_owner.adjustFireLoss(-HEMOKINETIC_REGEN_HEALING * seconds_between_ticks, updating_health = FALSE, required_bodytype = BODYTYPE_ORGANIC)
	if(amount_healed)
		carbon_owner.blood_volume -= (HEMOKINETIC_REGEN_BLOOD_CONSUMPTION * amount_healed)
```

## Changelog

:cl:
balance: Hemophage heal ability healing brute AND burn per second 1.8 => 0.5
balance: Hemophage heal ability blood consumption 0.9 => 1.0
/:cl:

****
- [x] Проверено на локалке
