### PR TITLE
fix: goliath hide wearable icon is longer error

### DIFF
--- a/modular_ss220/modules/fixes_minor_1984/default_wearable_iconstate/leather.dm
+++ b/modular_ss220/modules/fixes_minor_1984/default_wearable_iconstate/leather.dm
@@ -1,0 +1,4 @@
+/obj/item/stack/sheet/animalhide/goliath_hide/New()
+	. = ..()
+	if (isnull(worn_icon_state))
+		worn_icon_state = "nothing"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9680,6 +9680,7 @@
 #include "modular_ss220\modules\fixes_minor_1984\no_bitrun_huduse\human.dm"
 #include "modular_ss220\modules\fixes_minor_1984\bitrun_stuff\outfits.dm"
 #include "modular_ss220\modules\fixes_minor_1984\default_wearable_iconstate\items.dm"
+#include "modular_ss220\modules\fixes_minor_1984\default_wearable_iconstate\leather.dm"
 #include "modular_ss220\modules\votes_stuff\transfer_vote.dm"
 #include "modular_ss220\modules\votes_stuff\autotransfer.dm"
 #include "modular_ss220\modules\qol_casual_1984\engivend_jetpacks\modules_general.dm"


### PR DESCRIPTION
## Changelog

:cl:
fix: Goliath hide plates no longer have error (purple) icon when worn, instead have invisible overlay
/:cl:

****
- [x] Проверено на локалке
