### PR TITLE
fix: runechat with languages is no longer shows ('')

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -179,7 +179,7 @@
 			LAZYSET(language_icons, language, language_icon)
 		LAZYADD(prefixes, "\icon[language_icon]")
 
-	text = "[prefixes?.Join("{'\u00A0'}")][text]"
+	text = "[prefixes?.Join("&nbsp;")][text]"
 
 	// We dim italicized text to make it more distinguishable from regular text
 	var/tgt_color = extra_classes.Find("italics") ? target.chat_color_darkened : target.chat_color


### PR DESCRIPTION
## Changelog

:cl:
fix: runechat with languages is no longer shows ('')
/:cl:

****
- [x] Проверено на локалке
