### PR TITLE
fix: oldstation spawners update

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldstation1984.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation1984.dmm
@@ -2398,7 +2398,7 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mob_spawn/ghost_role/human/oldsec,
+/obj/effect/mob_spawn/ghost_role/human/oldstation/sec,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/dorms)
@@ -2640,7 +2640,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mob_spawn/ghost_role/human/oldeng,
+/obj/effect/mob_spawn/ghost_role/human/oldstation/eng,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/dorms)
 "lo" = (
@@ -2668,7 +2668,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mob_spawn/ghost_role/human/oldsci,
+/obj/effect/mob_spawn/ghost_role/human/oldstation/sci,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/dorms)
 "lw" = (
@@ -8071,7 +8071,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mob_spawn/ghost_role/human/oldmed,
+/obj/effect/mob_spawn/ghost_role/human/oldstation/med,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/dorms)
 "TZ" = (

--- a/modular_ss220/modules/rolesedit/code/old_station/oldstation.dm
+++ b/modular_ss220/modules/rolesedit/code/old_station/oldstation.dm
@@ -360,39 +360,29 @@
 
 //spawner override
 
-/obj/effect/mob_spawn/ghost_role/human/oldeng
+/obj/effect/mob_spawn/ghost_role/human/oldstation
+	random_appearance = FALSE
 	restricted_species = list(/datum/species/human, /datum/species/human/felinid, /datum/species/synthetic)
 
-/obj/effect/mob_spawn/ghost_role/human/oldsci
+/obj/effect/mob_spawn/ghost_role/human/oldstation/eng
 	restricted_species = list(/datum/species/human, /datum/species/human/felinid, /datum/species/synthetic)
 
-/obj/effect/mob_spawn/ghost_role/human/oldsec
+/obj/effect/mob_spawn/ghost_role/human/oldstation/sci
 	restricted_species = list(/datum/species/human, /datum/species/human/felinid, /datum/species/synthetic)
 
+/obj/effect/mob_spawn/ghost_role/human/oldstation/sec
+	restricted_species = list(/datum/species/human, /datum/species/human/felinid, /datum/species/synthetic)
 
 
 //medic spawner
-
-/obj/effect/mob_spawn/ghost_role/human/oldmed
-	name = "old cryogenics pod"
+/obj/effect/mob_spawn/ghost_role/human/oldstation/med
 	desc = "A humming cryo pod. You can barely recognise an medical uniform underneath the built up ice. The machine is attempting to wake up its occupant."
 	prompt_name = "a medical doctor"
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
-	mob_species = /datum/species/human
 	you_are_text = "You are a medical doctor working for Nanotrasen, stationed onboard a state of the art research station."
-	flavour_text = "You vaguely recall rushing into a cryogenics pod due to an oncoming radiation storm. The last thing \
-	you remember is the station's Artificial Program telling you that you would only be asleep for eight hours. As you open \
-	your eyes, everything seems rusted and broken, a dark feeling swells in your gut as you climb out of your pod."
-	important_text = "Work as a team with your fellow survivors and do not abandon them."
 	outfit = /datum/outfit/oldmed
-	spawner_job_path = /datum/job/ancient_crew
-	random_appearance = FALSE
 	restricted_species = list(/datum/species/human, /datum/species/human/felinid, /datum/species/synthetic)
-
-/obj/effect/mob_spawn/ghost_role/human/oldmed/Destroy()
-	new/obj/structure/showcase/machinery/oldpod/used(drop_location())
-	return ..()
 
 // medic closet(for beta station)
 


### PR DESCRIPTION
## Описание
обновил модульную старую станцию чтобы спавнеры были правильные


## Changelog

:cl:
fix: oldstation spawners now have proper description in spawn menu and notify ghosts
/:cl:

- [x] Проверено на локалке
