### PR TITLE
fix: spent ammo is now dropped as spent when reloading with ammo box

### DIFF
--- a/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
@@ -52,6 +52,7 @@
 
 		if(bullet)
 			bullet.forceMove(drop_location())
+			bullet.update_appearance() // SS1984 ADDITION
 		return TRUE
 	return FALSE
 

--- a/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
@@ -52,7 +52,6 @@
 
 		if(bullet)
 			bullet.forceMove(drop_location())
-			bullet.update_appearance() // SS1984 ADDITION
 		return TRUE
 	return FALSE
 

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -562,6 +562,7 @@
 /obj/item/gun/ballistic/proc/load_gun(obj/item/ammo, mob/living/user)
 	if (chambered && !chambered.loaded_projectile)
 		chambered.forceMove(drop_location())
+		chambered.update_appearance() // SS1984 ADDITION
 		if(magazine && magazine.stored_ammo.len > 0 && chambered != magazine.stored_ammo[1]) // SS1984 EDIT, original: if(chambered != magazine?.stored_ammo[1])
 			magazine.stored_ammo -= chambered
 		set_chambered(null) // SS1984 EDIT, original: chambered = null


### PR DESCRIPTION
## Changelog

:cl:
fix: Spent ammo is now correctly shown as spent when reloaded with ammo box
/:cl:

****
- [x] Проверено на локалке
