### PR TITLE
fix: Airlock access circuit no longer TGUI NTOS from invalid accesses

### DIFF
--- a/code/modules/mapping/access_helpers.dm
+++ b/code/modules/mapping/access_helpers.dm
@@ -8,14 +8,26 @@
 		log_mapping("[src] at [AREACOORD(src)] tried to set req_one_access, but req_access was already set!")
 	else
 		var/list/access_list = get_access()
-		airlock.req_one_access += access_list
+		// SS1984 REMOVAL airlock.req_one_access += access_list
+		// SS1984 ADDITION START
+		for(var/access in access_list)
+			if (access in airlock.req_one_access)
+				continue
+			airlock.req_one_access += access
+		// SS1984 ADDITION END
 
 /obj/effect/mapping_helpers/airlock/access/all/payload(obj/machinery/door/airlock/airlock)
 	if(airlock.req_one_access != null)
 		log_mapping("[src] at [AREACOORD(src)] tried to set req_one_access, but req_access was already set!")
 	else
 		var/list/access_list = get_access()
-		airlock.req_access += access_list
+		// SS1984 REMOVAL airlock.req_access += access_list
+		// SS1984 ADDITION START
+		for(var/access in access_list)
+			if (access in airlock.req_access)
+				continue
+			airlock.req_access += access
+		// SS1984 ADDITION END
 
 /obj/effect/mapping_helpers/airlock/access/proc/get_access()
 	var/list/access = list()

--- a/code/modules/mapping/access_helpers.dm
+++ b/code/modules/mapping/access_helpers.dm
@@ -8,26 +8,14 @@
 		log_mapping("[src] at [AREACOORD(src)] tried to set req_one_access, but req_access was already set!")
 	else
 		var/list/access_list = get_access()
-		// SS1984 REMOVAL airlock.req_one_access += access_list
-		// SS1984 ADDITION START
-		for(var/access in access_list)
-			if (access in airlock.req_one_access)
-				continue
-			airlock.req_one_access += access
-		// SS1984 ADDITION END
+		airlock.req_one_access += access_list
 
 /obj/effect/mapping_helpers/airlock/access/all/payload(obj/machinery/door/airlock/airlock)
 	if(airlock.req_one_access != null)
 		log_mapping("[src] at [AREACOORD(src)] tried to set req_one_access, but req_access was already set!")
 	else
 		var/list/access_list = get_access()
-		// SS1984 REMOVAL airlock.req_access += access_list
-		// SS1984 ADDITION START
-		for(var/access in access_list)
-			if (access in airlock.req_access)
-				continue
-			airlock.req_access += access
-		// SS1984 ADDITION END
+		airlock.req_access += access_list
 
 /obj/effect/mapping_helpers/airlock/access/proc/get_access()
 	var/list/access = list()

--- a/modular_ss220/modules/upstream-fixes/airlock_ntos/airlock_electronics.dm
+++ b/modular_ss220/modules/upstream-fixes/airlock_ntos/airlock_electronics.dm
@@ -1,0 +1,4 @@
+/obj/item/electronics/airlock/ui_data()
+	if (isnull(accesses))
+		accesses = list()
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9622,6 +9622,7 @@
 #include "modular_ss220\modules\upstream-fixes\aicontroller_ghostize\ai_controller.dm"
 #include "modular_ss220\modules\upstream-fixes\emotes_restrictions\emote.dm"
 #include "modular_ss220\modules\upstream-fixes\hulk_loss_on_death\hulk.dm"
+#include "modular_ss220\modules\upstream-fixes\airlock_ntos\airlock_electronics.dm"
 #include "modular_ss220\modules\vendors\code\dorms.dm"
 #include "modular_ss220\modules\restrict-species\restrict_species.dm"
 #include "modular_ss220\modules\disabled_station_traits\negative_traits.dm"


### PR DESCRIPTION
Очень примитивно, но критично лишь перед открытием интерфейса
по логике accesses и вовсе никогда не должны быть null, но это происходит
подобный фикс не создает проблем и работает тогда, когда это действительно необходимо

## Changelog

:cl:
fix: Airlock access circuit no longer TGUI NTOS from invalid accesses
/:cl:

****
- [x] Проверено на локалке
