### PR TITLE
fix: xeno tails is no longer available roundstart & on random spawn

### DIFF
--- a/code/modules/surgery/organs/external/tails.dm
+++ b/code/modules/surgery/organs/external/tails.dm
@@ -219,7 +219,7 @@
 ///Alien tail bodypart overlay
 /datum/bodypart_overlay/mutant/tail/xeno
 	color_source = NONE
-	feature_key = FEATURE_TAIL // NOVA EDIT CHANGE - CUSTOMIZATION - ORIGINAL: feature_key = FEATURE_TAIL_XENO
+	feature_key = FEATURE_TAIL_XENO // SS1984 REVERT OF NOVA'S EDIT, original: feature_key = FEATURE_TAIL // NOVA EDIT CHANGE - CUSTOMIZATION - ORIGINAL: feature_key = FEATURE_TAIL_XENO
 	imprint_on_next_insertion = FALSE
 	/// We don't want to bother writing this in DNA, just use this appearance
 	var/default_appearance = "Xeno"

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/tails.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/tails.dm
@@ -531,8 +531,10 @@
 /datum/sprite_accessory/tails/fish/chonky
 	name = "Chonky (Fish Infusion)"
 
-/datum/sprite_accessory/tails/xeno
-	feature_key_override = FEATURE_TAIL_XENO
+// SS1984 REMOVAL START
+// /datum/sprite_accessory/tails/xeno
+// 	feature_key_override = FEATURE_TAIL_XENO
+// SS1984 REMOVAL END
 
 /datum/sprite_accessory/tails/xeno/queen
 	locked = TRUE

--- a/modular_ss220/modules/disable_upstream_stuff/no_weird_tails_roundstart/sprite_accesories.dm
+++ b/modular_ss220/modules/disable_upstream_stuff/no_weird_tails_roundstart/sprite_accesories.dm
@@ -3,4 +3,5 @@
 	natural_spawn = FALSE
 
 /datum/sprite_accessory/tails/mammal/wagging/xeno_tail
+	locked = TRUE
 	natural_spawn = FALSE

--- a/modular_ss220/modules/disable_upstream_stuff/no_weird_tails_roundstart/sprite_accesories.dm
+++ b/modular_ss220/modules/disable_upstream_stuff/no_weird_tails_roundstart/sprite_accesories.dm
@@ -1,3 +1,6 @@
 /datum/sprite_accessory/tails/xeno
 	locked = TRUE
 	natural_spawn = FALSE
+
+/datum/sprite_accessory/tails/mammal/wagging/xeno_tail
+	natural_spawn = FALSE

--- a/modular_ss220/modules/disable_upstream_stuff/no_weird_tails_roundstart/sprite_accesories.dm
+++ b/modular_ss220/modules/disable_upstream_stuff/no_weird_tails_roundstart/sprite_accesories.dm
@@ -1,0 +1,3 @@
+/datum/sprite_accessory/tails/xeno
+	locked = TRUE
+	natural_spawn = FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9679,6 +9679,7 @@
 #include "modular_ss220\modules\disable_upstream_stuff\safety_additions.dm"
 #include "modular_ss220\modules\disable_upstream_stuff\no_default_nif_examine\nifs.dm"
 #include "modular_ss220\modules\disable_upstream_stuff\no_light_flicker\lightning.dm"
+#include "modular_ss220\modules\disable_upstream_stuff\no_weird_tails_roundstart\sprite_accesories.dm"
 #include "modular_ss220\modules\extended_smes\machine_circuitboards.dm"
 #include "modular_ss220\modules\extended_smes\smes.dm"
 #include "modular_ss220\modules\crew_manifest_colored\crewmanifest.dm"


### PR DESCRIPTION
Настолько широкая кастомизация у Новы, что мы получаем спавн рандомных пеплоходцев с хвостами королевы, который даже у них в LOCKED, но это просто не работает

## Changelog

:cl:
fix: xeno tails is no longer spawn on random mobs
fix: real xenomorph tails (such as Xeno Queen) no longer available on roundstart
/:cl:

****
- [x] Проверено на локалке
