### PR TITLE
balance: revert "Shotgun shells have been adjusted..."

### DIFF
--- a/modular_ss220/modules/balance-1984/old_ballistics_damage/shotgun.dm
+++ b/modular_ss220/modules/balance-1984/old_ballistics_damage/shotgun.dm
@@ -47,3 +47,10 @@
 	wound_bonus = 0
 	exposed_wound_bonus = 20
 
+/obj/projectile/bullet/pellet/flechette
+	damage = 2
+	damage_falloff_tile = -0.2
+	speed = 1.2
+
+/datum/embedding/bullet/flechette
+	embed_chance = 25


### PR DESCRIPTION
## Changelog

:cl:
balance: Revert "Shotgun shells have been adjusted, with the most drastic change being on shotgun slugs, going from 30 damage 10 AP to 35 damage 30 AP, giving them more of an anti-armor niche. Some other shotguns may have been touched, see PR 6371 for details as they come along."
/:cl:
