### PR TITLE
balance: portal storm event spawn

### DIFF
--- a/modular_ss220/modules/events/round_event.dm
+++ b/modular_ss220/modules/events/round_event.dm
@@ -5,3 +5,9 @@
 /datum/round_event_control/wall_fungus
 	weight = 7
 	min_players = 30
+
+/datum/round_event_control/portal_storm_syndicate
+	max_occurrences = 1
+
+/datum/round_event_control/portal_storm_narsie
+	max_occurrences = 0


### PR DESCRIPTION
## Описание
убрал спавн ивента культистов 


## Changelog
:cl:
balance: disabled cult construct event random spawn, decreased max syndicate portal storm random event to 1
/:cl:
