### PR TITLE
fix: id upgrade machine work while broken/not powered

### DIFF
--- a/modular_ss220/modules/access_upgrader/code/upgrader.dm
+++ b/modular_ss220/modules/access_upgrader/code/upgrader.dm
@@ -16,6 +16,9 @@
 /obj/machinery/computer/id_upgrader/attackby(obj/item/I, mob/user, params)
 	if(I.GetID())
 		var/obj/item/card/id/D = I.GetID()
+		if((machine_stat & (NOPOWER|BROKEN|MAINT)))
+			to_chat(user, "<span class='notice'>This machine appears to be not operational.</span>")
+			return
 		if(!access_to_give.len)
 			to_chat(user, "<span class='notice'>This machine appears to be configured incorrectly.</span>")
 			return


### PR DESCRIPTION
## Описание
Починил ошибку при которой машина выдавала доступ даже в неработоспособном состоянии(добавил проверку)


## Changelog

:cl:
fix: ID upgrade machine(ghost role/event computer) no longer work while broken/not powered
/:cl:

- [x] Проверено на локалке