### PR TITLE
balance: Revert "Removes Mining ID's and Mining Headset Keys..."

### DIFF
--- a/code/game/objects/items/storage/dufflebags.dm
+++ b/code/game/objects/items/storage/dufflebags.dm
@@ -402,16 +402,16 @@
 	new /obj/item/clothing/glasses/meson(src)
 	new /obj/item/t_scanner/adv_mining_scanner/lesser(src)
 	new /obj/item/storage/bag/ore(src)
-	/* // NOVA EDIT REMOVAL - START
+	// SS1984 REMOVAL START, revert of nova's removal /* // NOVA EDIT REMOVAL - START
 	new /obj/item/clothing/suit/hooded/explorer(src)
 	new /obj/item/encryptionkey/headset_mining(src)
 	new /obj/item/clothing/mask/gas/explorer(src)
 	new /obj/item/card/id/advanced/mining(src)
-	*/ // NOVA EDIT REMOVAL - END
-	// NOVA EDIT ADDITION - START
-	new /obj/item/clothing/suit/hooded/seva(src)
-	new /obj/item/clothing/mask/gas/seva(src)
-	// NOVA EDIT ADDITION - END
+	// SS1984 REMOVAL END, revert of nova's removal */ // NOVA EDIT REMOVAL - END
+	// // NOVA EDIT ADDITION - START
+	// new /obj/item/clothing/suit/hooded/seva(src)
+	// new /obj/item/clothing/mask/gas/seva(src)
+	// // NOVA EDIT ADDITION - END // SS1984 REMOVAL END
 	new /obj/item/gun/energy/recharge/kinetic_accelerator(src)
 	new /obj/item/knife/combat/survival(src)
 	new /obj/item/flashlight/seclite(src)


### PR DESCRIPTION
## Changelog

:cl:
balance: Revert "Removes Mining ID's and Mining Headset Keys from the Conscript Kit. Makes the kit requires no access so you can be a yanky miner as you always dreamed! Replaces the Explorer suit with a Seva suit, better fitted for civilians trying to be a miner than real monster hunter miners."
/:cl:
