### PR TITLE
del: Remove non-actual policy text for primitive catgirl ghostrole

### DIFF
--- a/modular_nova/modules/primitive_catgirls/code/spawner.dm
+++ b/modular_nova/modules/primitive_catgirls/code/spawner.dm
@@ -39,8 +39,7 @@
 /obj/effect/mob_spawn/ghost_role/human/primitive_catgirl/Initialize(mapload)
 	. = ..()
 	team = new /datum/team/primitive_catgirls()
-
-	important_text = "Read the full policy <a href=\"[CONFIG_GET(string/icecats_policy_link)]\">here</a>."
+	// SS1984 REMOVAL important_text = "Read the full policy <a href=\"[CONFIG_GET(string/icecats_policy_link)]\">here</a>."
 
 /obj/effect/mob_spawn/ghost_role/human/primitive_catgirl/Destroy()
 	team = null


### PR DESCRIPTION
## Changelog

:cl:
del: Remove non-actual policy text for primitive catgirl ghostrole (ice-dwellers)
/:cl:
