### PR TITLE
fix: paper UI two whitespaces no longer translated to {'  "}

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -653,7 +653,7 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 
 	t = replacetext(t, regex("(?:\\r\\n?|\\n)", "g"), "<br>")
 
-	t = replacetext(t, "  ", "{'\u00A0'}{'\u00A0'}")
+	t = replacetext(t, "  ", "&nbsp;&nbsp;")
 
 	// Done
 


### PR DESCRIPTION
## Changelog

:cl:
fix: Paper UI two whitespaces no longer translated to {'  "} on writing
/:cl:

****
- [x] Проверено на локалке
