### PR TITLE
fix: icebox runtime + modular syndicate ghostrole map fixes

### DIFF
--- a/_maps/RandomRuins/IceRuins/nova/icemoon_underground_interdyne_base1984.dmm
+++ b/_maps/RandomRuins/IceRuins/nova/icemoon_underground_interdyne_base1984.dmm
@@ -1968,7 +1968,7 @@
 /obj/machinery/iv_drip,
 /obj/machinery/defibrillator_mount/loaded{
 	pixel_x = 28;
-    req_one_access = list()
+	req_one_access = list()
 	},
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/interdyne_planetary_base/med)
@@ -2665,15 +2665,15 @@
 	ailock = 1
 	},
 /obj/item/folder/syndicate/red/secretformula,
-/obj/item/circuitboard/computer/syndiepad{
+/obj/item/circuitboard/computer/ghostpad/interdyne{
 	pixel_x = 2;
 	pixel_y = 2
 	},
-/obj/item/circuitboard/machine/syndiepad{
+/obj/item/circuitboard/machine/ghostpad/interdyne{
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/item/circuitboard/computer/cargo/express/interdyne{
+/obj/item/circuitboard/computer/cargo/express/ghost/interdyne{
 	pixel_x = 6;
 	pixel_y = 6
 	},
@@ -5369,7 +5369,7 @@
 /obj/machinery/cryopod{
 	dir = 4
 	},
-/obj/machinery/computer/cryopod/interdyne/directional/west{
+/obj/machinery/computer/cryopod/directional/west{
 	req_one_access = list("syndicate")
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -7537,7 +7537,6 @@
 "WA" = (
 /obj/item/gun/ballistic/rifle/sniper_rifle/syndicate,
 /obj/structure/rack/gunrack,
-/obj/item/ammo_workbench_reboot,
 /obj/item/ammo_workbench_module/lethal_super/evil,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/main/vault)

--- a/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1984.dmm
+++ b/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1984.dmm
@@ -1267,7 +1267,9 @@
 /obj/effect/turf_decal/tile/dark_green/half{
 	dir = 8
 	},
-/obj/machinery/computer/cryopod/interdyne/directional/west,
+/obj/machinery/computer/cryopod/directional/west{
+	req_one_access = list("syndicate")
+	},
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
@@ -5739,15 +5741,15 @@
 "UE" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/syndicate/red/secretformula,
-/obj/item/circuitboard/computer/syndiepad{
+/obj/item/circuitboard/computer/ghostpad/interdyne{
 	pixel_x = 2;
 	pixel_y = 2
 	},
-/obj/item/circuitboard/machine/syndiepad{
+/obj/item/circuitboard/machine/ghostpad/interdyne{
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/item/circuitboard/computer/cargo/express/interdyne{
+/obj/item/circuitboard/computer/cargo/express/ghost/interdyne{
 	pixel_x = 6;
 	pixel_y = 6
 	},

--- a/code/modules/unit_tests/simple_animal_freeze.dm
+++ b/code/modules/unit_tests/simple_animal_freeze.dm
@@ -55,7 +55,7 @@
 		/mob/living/simple_animal/hostile/ooze,
 		/mob/living/simple_animal/hostile/ooze/gelatinous,
 		/mob/living/simple_animal/hostile/ooze/grapes,
-		/mob/living/simple_animal/soulscythe,
+		// SS1984 ADDITION START
 		/mob/living/simple_animal/hostile/blackmesa,
 		/mob/living/simple_animal/hostile/blackmesa/xen,
 		/mob/living/simple_animal/hostile/blackmesa/xen/headcrab_zombie,
@@ -78,6 +78,7 @@
 		/mob/living/simple_animal/hostile/blackmesa/sec/ranged,
 		/mob/living/simple_animal/hostile/blackmesa/blackops,
 		/mob/living/simple_animal/hostile/blackmesa/blackops/ranged,
+		// SS1984 ADDITION END
 
 		// MODULAR NOVA ENTRIES
 		// PLEASE REFACTOR THESE AS YOU CAN


### PR DESCRIPTION
## Changelog

:cl:
fix: Returned some missing items on interdyne (cryopod, cargo express circuit boards)
/:cl:

****
- [x] Проверено на локалке
