### PR TITLE
config: restart vote for lowpop

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -669,3 +669,6 @@ TGUI_MAX_CHUNK_COUNT 32
 
 ## Minimum time before a heretic can ascend, in minutes
 # MINIMUM_ASCENSION_TIME 3
+
+## Max online when restart vote is available for players SS1984 ADDITION
+VOTE_RESTART_MAX_ONLINE 5

--- a/config/config_server.txt
+++ b/config/config_server.txt
@@ -128,7 +128,7 @@ ALLOW_ADMIN_ASAYCOLOR
 ID_CONSOLE_JOBSLOT_DELAY 30
 
 ## allow players to initiate a restart vote
-#ALLOW_VOTE_RESTART
+ALLOW_VOTE_RESTART
 
 ## allow players to initiate a map-change vote
 #ALLOW_VOTE_MAP
@@ -662,3 +662,9 @@ TGUI_MAX_CHUNK_COUNT 32
 
 ## Disables all tutorials if uncommented
 DISABLE_TUTORIALS
+
+## Minimum time before a heretic can ascend, in minutes
+# MINIMUM_ASCENSION_TIME 3
+
+## Max online when restart vote is available for players SS1984 ADDITION
+VOTE_RESTART_MAX_ONLINE 5

--- a/modular_ss220/modules/votes_stuff/restart_vote.dm
+++ b/modular_ss220/modules/votes_stuff/restart_vote.dm
@@ -4,9 +4,6 @@
 	integer = TRUE
 	min_val = 0
 
-/datum/vote/restart_vote/is_config_enabled()
-	return CONFIG_GET(flag/allow_vote_restart) && GLOB.player_list.len < CONFIG_GET(number/vote_restart_max_online)
-
 /datum/vote/restart_vote/can_be_initiated(forced = FALSE)
 	. = ..()
 

--- a/modular_ss220/modules/votes_stuff/restart_vote.dm
+++ b/modular_ss220/modules/votes_stuff/restart_vote.dm
@@ -1,3 +1,9 @@
+/// maximum online when restart vote is available to players
+/datum/config_entry/number/vote_restart_max_online
+	default = 999
+	integer = TRUE
+	min_val = 0
+
 /datum/vote/restart_vote/is_config_enabled()
 	return CONFIG_GET(flag/allow_vote_restart) && GLOB.player_list.len < CONFIG_GET(number/vote_restart_max_online)
 

--- a/modular_ss220/modules/votes_stuff/restart_vote.dm
+++ b/modular_ss220/modules/votes_stuff/restart_vote.dm
@@ -1,0 +1,14 @@
+/datum/vote/restart_vote/is_config_enabled()
+	return CONFIG_GET(flag/allow_vote_restart) && GLOB.player_list.len < CONFIG_GET(number/vote_restart_max_online)
+
+/datum/vote/restart_vote/can_be_initiated(forced = FALSE)
+	. = ..()
+
+	if(. != VOTE_AVAILABLE || forced)
+		return .
+
+	var/max_allowed_players = CONFIG_GET(number/vote_restart_max_online)
+	if (GLOB.player_list.len < max_allowed_players)
+		return .
+
+	return "This vote is only available with less than [max_allowed_players] online!"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9743,6 +9743,7 @@
 #include "modular_ss220\modules\fixes_minor_1984\default_wearable_iconstate\leather.dm"
 #include "modular_ss220\modules\votes_stuff\transfer_vote.dm"
 #include "modular_ss220\modules\votes_stuff\autotransfer.dm"
+#include "modular_ss220\modules\votes_stuff\restart_vote.dm"
 #include "modular_ss220\modules\qol_casual_1984\engivend_jetpacks\modules_general.dm"
 #include "modular_ss220\modules\qol_casual_1984\engivend_jetpacks\engivend.dm"
 #include "modular_ss220\modules\qol_casual_1984\healthanalyzer_autolathe\medical_designs.dm"


### PR DESCRIPTION
Дополнительно добавляет в config_server то, что не мержится автоматически

## Changelog

:cl:
config: Restart vote is enabled
config: Restart vote is available to players only with < 5 online
/:cl:

****
- [x] Проверено на локалке