### PR TITLE
fix: return missing cargo plates at DS2

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/des_two1984.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/des_two1984.dmm
@@ -5216,12 +5216,12 @@
 	req_access = list("syndicate")
 	},
 /obj/structure/table,
-/obj/item/circuitboard/machine/syndiepad/syndicate,
-/obj/item/circuitboard/computer/syndiepad/syndicate{
+/obj/item/circuitboard/machine/ghostpad/syndicate,
+/obj/item/circuitboard/computer/ghostpad/syndicate{
 	pixel_x = 2;
 	pixel_y = 2
 	},
-/obj/item/circuitboard/computer/cargo/express/interdyne/syndicate{
+/obj/item/circuitboard/computer/cargo/express/ghost/syndicate{
 	pixel_y = 4;
 	pixel_x = 4
 	},


### PR DESCRIPTION
## Changelog

:cl:
fix: Missing cargo plates at DS2 added back
/:cl:

****
- [x] Проверено на локалке