### PR TITLE
fix: Shuttle transfer vote is working as it says now

### DIFF
--- a/modular_ss220/modules/votes_stuff/transfer_vote.dm
+++ b/modular_ss220/modules/votes_stuff/transfer_vote.dm
@@ -29,7 +29,7 @@
 	return "This vote is only accesible after [EARLY_VOTE_FORBID_BEFORE_THRESHOLD_IN_MINS] minutes round time, however after [EARLY_VOTE_FORBID_AFTER_THRESHOLD_IN_MINS] minutes it will be disabled. But, once [LATE_VOTE_ALLOW_THRESHOLD_IN_MINS] minutes is passed, vote is enabled again."
 
 /datum/vote/transfer_vote/proc/get_available_at_time()
-	if (!SSticker || !Master || !Master.current_runlevel != RUNLEVEL_GAME)
+	if (!SSticker || !Master || !(Master.current_runlevel & RUNLEVEL_GAME)) // bitwise check with dividing, if not RUNLEVEL_GAME - then return false
 		return FALSE
 	var/ticks_passed = STATION_TIME_PASSED()
 	if (ticks_passed < EARLY_VOTE_FORBID_BEFORE_THRESHOLD)

--- a/modular_ss220/modules/votes_stuff/transfer_vote.dm
+++ b/modular_ss220/modules/votes_stuff/transfer_vote.dm
@@ -29,8 +29,12 @@
 	return "This vote is only accesible after [EARLY_VOTE_FORBID_BEFORE_THRESHOLD_IN_MINS] minutes round time, however after [EARLY_VOTE_FORBID_AFTER_THRESHOLD_IN_MINS] minutes it will be disabled. But, once [LATE_VOTE_ALLOW_THRESHOLD_IN_MINS] minutes is passed, vote is enabled again."
 
 /datum/vote/transfer_vote/proc/get_available_at_time()
-	if (!SSticker || !Master || !(Master.current_runlevel & RUNLEVEL_GAME)) // bitwise check with dividing, if not RUNLEVEL_GAME - then return false
+	if (!SSticker || !Master)
 		return FALSE
+
+	if (SSticker.current_state != GAME_STATE_PLAYING)
+		return FALSE
+
 	var/ticks_passed = STATION_TIME_PASSED()
 	if (ticks_passed < EARLY_VOTE_FORBID_BEFORE_THRESHOLD)
 		return FALSE // someone didn't rolled antag or something like nuke ops mode?


### PR DESCRIPTION
## Changelog

:cl:
fix: Transfer vote (in vote panel) now working as it's tooltip says
/:cl:

****
- [x] Проверено на локалке