### PR TITLE
fix: ghostpads selling is work again

### DIFF
--- a/modular_ss220/modules/plasma_inflation/syndiepad.dm
+++ b/modular_ss220/modules/plasma_inflation/syndiepad.dm
@@ -1,11 +1,11 @@
-/obj/machinery/computer/piratepad_control
+/obj/machinery/computer/piratepad_control/ghostpad
 	var/target_market_to_export = EXPORT_MARKET_PIRACY
 
-/obj/machinery/computer/piratepad_control/syndiepad // it's interdyne
+/obj/machinery/computer/piratepad_control/ghostpad/interdyne // it's interdyne
 	target_market_to_export = EXPORT_MARKET_DS_INTERDYNE
 
-/obj/machinery/computer/piratepad_control/syndiepad/syndicate // DS-2
+/obj/machinery/computer/piratepad_control/ghostpad/syndicate // DS-2
 	target_market_to_export = EXPORT_MARKET_DS_INTERDYNE
 
-/obj/machinery/computer/piratepad_control/syndiepad/tarkon
+/obj/machinery/computer/piratepad_control/ghostpad/tarkon
 	target_market_to_export = EXPORT_MARKET_TARKON

--- a/modular_ss220/modules/plasma_inflation/syndiepad.dm
+++ b/modular_ss220/modules/plasma_inflation/syndiepad.dm
@@ -2,7 +2,7 @@
 	var/target_market_to_export = EXPORT_MARKET_STATION
 
 /obj/machinery/computer/piratepad_control/ghostpad
-	var/target_market_to_export = EXPORT_MARKET_PIRACY
+	target_market_to_export = EXPORT_MARKET_PIRACY
 
 /obj/machinery/computer/piratepad_control/ghostpad/interdyne // it's interdyne
 	target_market_to_export = EXPORT_MARKET_DS_INTERDYNE

--- a/modular_ss220/modules/plasma_inflation/syndiepad.dm
+++ b/modular_ss220/modules/plasma_inflation/syndiepad.dm
@@ -1,3 +1,6 @@
+/obj/machinery/computer/piratepad_control
+	var/target_market_to_export = EXPORT_MARKET_STATION
+
 /obj/machinery/computer/piratepad_control/ghostpad
 	var/target_market_to_export = EXPORT_MARKET_PIRACY
 


### PR DESCRIPTION
## Changelog

:cl:
fix: ghostpads (such as DS-2, Interdyne, Tarkon) selling is work again
/:cl:

****
- [x] Проверено на локалке
