### PR TITLE
fix: ghostrole rd consoles are unlocked again

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/des_two1984.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/des_two1984.dmm
@@ -3597,7 +3597,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/item/circuitboard/computer/rdconsole,
+/obj/item/circuitboard/computer/rdconsole/unlocked,
 /obj/structure/frame/computer{
 	dir = 8
 	},

--- a/_maps/RandomRuins/SpaceRuins/oldstation1984.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation1984.dmm
@@ -1079,7 +1079,7 @@
 /turf/open/floor/iron/diagonal,
 /area/ruin/space/ancientstation/beta/gravity)
 "eF" = (
-/obj/machinery/computer/rdconsole,
+/obj/machinery/computer/rdconsole/unlocked,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/ruin/space/ancientstation/delta/rnd)


### PR DESCRIPTION
Ченжлог не нужен, т.к. деплоя еще не было, до этого все так и работало