### PR TITLE
consistent world name & remove "hostedby" in hub status

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -106,7 +106,7 @@ GLOBAL_VAR(command_name)
 
 	var/config_server_name = CONFIG_GET(string/servername)
 	if(config_server_name)
-		world.name = "[config_server_name][config_server_name == GLOB.station_name ? "" : ": [html_decode(GLOB.station_name)]"]"
+		world.name = "[config_server_name]" // SS1984 EDIT, original: world.name = "[config_server_name][config_server_name == GLOB.station_name ? "" : ": [html_decode(GLOB.station_name)]"]"
 	else
 		world.name = html_decode(GLOB.station_name)
 

--- a/modular_nova/modules/tagline/code/world.dm
+++ b/modular_nova/modules/tagline/code/world.dm
@@ -24,8 +24,10 @@
 
 	features += "~[players] player[players == 1 ? "": "s"]"
 
-	if (!host && hostedby)
-		features += "hosted by <b>[hostedby]</b>"
+	// SS1984 REMOVAL START
+	// if (!host && hostedby)
+	// 	features += "hosted by <b>[hostedby]</b>"
+	// SS1984 REMOVAL END
 
 	if(length(features))
 		new_status += "\[[jointext(features, ", ")]"

--- a/modular_nova/modules/tagline/code/world.dm
+++ b/modular_nova/modules/tagline/code/world.dm
@@ -3,12 +3,12 @@
 	var/list/features = list()
 
 	var/new_status = ""
-	var/hostedby
+	// SS1984 REMOVAL var/hostedby
 	if(config)
 		var/server_name = CONFIG_GET(string/servername)
 		if (server_name)
 			new_status += "<b>[server_name]</b> &#8212; "
-		hostedby = CONFIG_GET(string/hostedby)
+		// SS1984 REMOVAL hostedby = CONFIG_GET(string/hostedby)
 
 	new_status += " ("
 	new_status += "<a href=\"[CONFIG_GET(string/discord_link)]\">"


### PR DESCRIPTION
В основном нужно, чтоб кравлер по одному названию считал часы в дальнейшем

## Changelog

:cl:
server: World name (such as displayed at top of game window) is now consistent and no longer uses station name
/:cl:

****
- [x] Проверено на локалке
