### PR TITLE
balance: shuttle call time is 5 minutes since red code

### DIFF
--- a/modular_ss220/modules/disable_upstream_stuff/consistent_shuttle_time/security_level_datums.dm
+++ b/modular_ss220/modules/disable_upstream_stuff/consistent_shuttle_time/security_level_datums.dm
@@ -1,0 +1,29 @@
+/datum/security_level/green
+	shuttle_call_time_mod = 1 // 10 minutes
+
+/datum/security_level/blue
+	shuttle_call_time_mod = 1 // 10 minutes
+
+/datum/security_level/red
+	shuttle_call_time_mod = 0.5 // 5 minutes
+
+/datum/security_level/delta
+	shuttle_call_time_mod = 0.5 // 5 minutes
+
+/datum/security_level/violet
+	shuttle_call_time_mod = 0.5 // 5 minutes
+
+/datum/security_level/orange
+	shuttle_call_time_mod = 0.5 // 5 minutes
+
+/datum/security_level/amber
+	shuttle_call_time_mod = 0.5 // 5 minutes
+
+/datum/security_level/epsilon
+	shuttle_call_time_mod = 0.5 // 5 minutes
+
+/datum/security_level/gamma
+	shuttle_call_time_mod = 0.5 // 5 minutes
+
+/datum/security_level/federal
+	shuttle_call_time_mod = 0.5 // 5 minutes

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9762,6 +9762,7 @@
 #include "modular_ss220\modules\disable_upstream_stuff\no_weird_tails_roundstart\sprite_accesories.dm"
 #include "modular_ss220\modules\disable_upstream_stuff\emitter_heal_sm_again\beam.dm"
 #include "modular_ss220\modules\disable_upstream_stuff\emitter_heal_sm_again\emitter.dm"
+#include "modular_ss220\modules\disable_upstream_stuff\consistent_shuttle_time\security_level_datums.dm"
 #include "modular_ss220\modules\extended_smes\machine_circuitboards.dm"
 #include "modular_ss220\modules\extended_smes\smes.dm"
 #include "modular_ss220\modules\crew_manifest_colored\crewmanifest.dm"


### PR DESCRIPTION
## Changelog

:cl:
balance: Shuttle call time on green & blue codes 15 -> 10 minutes
balance: Shuttle call time starting on red code 15 -> 5 minutes
/:cl:

****
- [x] Проверено на локалке