### PR TITLE
fix: some centcom fixes

### DIFF
--- a/_maps/map_files/generic/CentCom_1984.dmm
+++ b/_maps/map_files/generic/CentCom_1984.dmm
@@ -2923,6 +2923,12 @@
 /obj/item/flashlight/lamp,
 /obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/button/door/indestructible{
+	id = "CCSadminstore";
+	name = "Administrative Storage Shutters";
+	req_access = list("cent_captain");
+	pixel_x = -27
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
 "lD" = (
@@ -5216,9 +5222,10 @@
 /obj/item/kirbyplants/organic/plant21,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/button/door/indestructible{
-	id = "CCsec3";
+	id = "XCCertstore";
 	name = "CentCom Armory";
-	pixel_y = -28
+	pixel_y = -28;
+	req_access = list("cent_specops_officer")
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -143,7 +143,13 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 
 			var/datum/map_template/thunderdome_template = SSmapping.map_templates[THUNDERDOME_TEMPLATE_FILE]
 			thunderdome_template.should_place_on_top = FALSE
-			var/turf/thunderdome_corner = locate(thunderdome.x - 3, thunderdome.y - 1, 1) // have to do a little bit of coord manipulation to get it in the right spot
+			var/thunder_z = null // SS1984 ADD START
+			for(var/z in 1 to length(SSmapping.z_list))
+				if((SSmapping.z_list[z]).name == "CentCom_Station")
+					thunder_z = z
+					break
+			var/turf/thunderdome_corner = locate(thunderdome.x - 3, thunderdome.y - 1, (thunder_z)) // SS1984 ADD END, centcom on other lvl, debug area on lvl 1
+	//		var/turf/thunderdome_corner = locate(thunderdome.x - 3, thunderdome.y - 1, 1) // have to do a little bit of coord manipulation to get it in the right spot //SS1984 DISABLE
 			thunderdome_template.load(thunderdome_corner)
 
 		if("set_name")

--- a/modular_ss220/modules/rolesedit/code/centcom/crew/_access_override.dm
+++ b/modular_ss220/modules/rolesedit/code/centcom/crew/_access_override.dm
@@ -90,12 +90,12 @@
 /datum/id_trim/centcom/naval/rear_admiral/New()
 	. = ..()
 
-	access = (SSid_access.get_region_access_list(list(REGION_ACCESS_ALL_CENTCOM, REGION_ALL_STATION)) - ACCESS_CENT_FLEET_ADMIRAL)
+	access = (SSid_access.get_region_access_list(list(REGION_ALL_CENTCOM, REGION_ALL_STATION)) - ACCESS_CENT_FLEET_ADMIRAL)
 
 /datum/id_trim/centcom/admiral/New()
 	. = ..()
 
-	access = (SSid_access.get_region_access_list(list(REGION_ACCESS_ALL_CENTCOM, REGION_ALL_STATION)) - ACCESS_CENT_FLEET_ADMIRAL)
+	access = (SSid_access.get_region_access_list(list(REGION_ALL_CENTCOM, REGION_ALL_STATION)) - ACCESS_CENT_FLEET_ADMIRAL)
 
 /datum/id_trim/centcom/naval/admiral
 	assignment = JOB_NAVAL_ADMIRAL
@@ -103,7 +103,7 @@
 /datum/id_trim/centcom/naval/admiral/New()
 	. = ..()
 
-	access = (SSid_access.get_region_access_list(list(REGION_ACCESS_ALL_CENTCOM, REGION_ALL_STATION)) - ACCESS_CENT_FLEET_ADMIRAL)
+	access = (SSid_access.get_region_access_list(list(REGION_ALL_CENTCOM, REGION_ALL_STATION)) - ACCESS_CENT_FLEET_ADMIRAL)
 
 /datum/id_trim/centcom/naval/fleet_admiral
 	assignment = JOB_NAVAL_FLEET_ADMIRAL
@@ -111,4 +111,4 @@
 /datum/id_trim/centcom/naval/fleet_admiral/New()
 	. = ..()
 
-	access = (SSid_access.get_region_access_list(list(REGION_ACCESS_ALL_CENTCOM, REGION_ALL_STATION)))
+	access = (SSid_access.get_region_access_list(list(REGION_ALL_CENTCOM, REGION_ALL_STATION)))


### PR DESCRIPTION
## Описание

починил доступ высших цкшников(не выдавало регион цк адмиралам)
починил кнопку оружейки цк(была привязана не к той двери и не имела блокировки)
добавил кнопку подсобке офицеров цк к капитану цк

## Changelog

:cl:
fix: fixed centcom high ups access
map: fixed centcom armory button, added cent admin storage to captain office
/:cl:

- [x] Проверено на локалке
