### PR TITLE
fix: tarkon express console now finds tarkon cargo area

### DIFF
--- a/modular_ss220/modules/rolesedit/code/tarkon/tarkon.dm
+++ b/modular_ss220/modules/rolesedit/code/tarkon/tarkon.dm
@@ -55,3 +55,6 @@
 
 /obj/effect/mob_spawn/ghost_role/human/tarkon/director
 	spawner_job_path = /datum/job/tarkon/command
+
+/obj/machinery/computer/cargo/express/ghost/tarkon
+	landingzone = /area/ruin/space/has_grav/port_tarkon/cargo


### PR DESCRIPTION
По сути исправляет предупреждение о том, что экспресс консоль не может найти зону карго ```code\modules\cargo\expressconsole.dm:37```

- [x] Проверено на локалке