### PR TITLE
fix: experimental fix flickering paper TGUI

### DIFF
--- a/tgui/packages/tgui/interfaces/PaperSheet/Preview.tsx
+++ b/tgui/packages/tgui/interfaces/PaperSheet/Preview.tsx
@@ -154,9 +154,12 @@ export class PreviewView extends Component<PreviewViewProps> {
   }
 
   shouldComponentUpdate(nextProps: Readonly<PreviewViewProps>): boolean {
-    if (!this.props.canEdit) return true;
+    // SS1984 REMOVAL START
+    // if (!this.props.canEdit) return true;
 
-    return this.props.canEdit !== nextProps.canEdit;
+    // return this.props.canEdit !== nextProps.canEdit;
+    // SS1984 REMOVAL END
+    return false; // SS1984 ADDITION
   }
 
   // Creates the partial inline HTML for previewing or reading the paper from


### PR DESCRIPTION
При просмотре бумаге не в режиме редактирования (без ручки в руке), она постоянно мерцает, мешает выделить текст, но особенно заметно это при наличии изображений. Проблема скорее всего связана с браузером:

> well apparently contenteditable elements lose focus when your mouse accidentally hovers over the element of the same type
i doubt its a tgui issue
or even react issue
i think thats ie issue
because i have spend days searching the internet as to why the fuck could bare unupdating elements just keep losing fucking focus and never found as much as a hint at a similar problem
either its a curse dedicated solely at myself for the bad deeds i performed in the previous life or its ie specifically handling contenteditable elements specifially very poorly
as a test you can change input in the Input elements into contenteditable div, always return false on shouldComponentUpdate and then in messenger menu focus the input line and then move mouse upwards to where the messages are displayed
in my case the element instantly loses focus without triggering anything at all

Возможно отключение обновления компонента исправит проблему. Единственная потенциальная проблема которую вижу - это когда два человека смотрят на бумагу, и один из них ее редактируют - второй нет. И у второго бумага может сразу же не обновиться. Пока это не проверял, но даже этот случай несущественный, тогда как постоянное мерцание изображений сильно заметно.

## Changelog

:cl:
fix: Experimentally fixed paper TGUI (no more flickering images while not editing text + can easily copy text)
/:cl:

****
- [x] Проверено на локалке