### PR TITLE
balance: Security belts can hold 3 => 2 baton/gun

### DIFF
--- a/modular_ss220/modules/rolesedit/code/jobs/security.dm
+++ b/modular_ss220/modules/rolesedit/code/jobs/security.dm
@@ -49,3 +49,6 @@
 /obj/structure/closet/secure_closet/hos/PopulateContents()
 	..()
 	new /obj/item/detective_scanner(src) // QOL
+
+/datum/storage/security_belt
+	max_limited_store = 1 // can have 1 gun and 1 baton/other gun in belt (nova's value = 2)


### PR DESCRIPTION
## Changelog

:cl:
balance: Security belts can hold 3 => 2 baton/gun (1 baton + 1 gun OR 2 guns OR 2 batons)
/:cl:

****
- [x] Проверено на локалке