### PR TITLE
map: IP&DS2 update 15.01.2026

### DIFF
--- a/_maps/RandomRuins/IceRuins/nova/icemoon_underground_interdyne_base1984.dmm
+++ b/_maps/RandomRuins/IceRuins/nova/icemoon_underground_interdyne_base1984.dmm
@@ -41,10 +41,8 @@
 /turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/ruin/interdyne_planetary_base/cargo)
 "aj" = (
-/obj/effect/mob_spawn/ghost_role/human/interdyne_planetary_base/deck_officer/ice{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/suit_storage_unit/syndicate/chameleon,
 /turf/open/floor/wood,
 /area/ruin/interdyne_planetary_base/cargo/deck)
 "ak" = (
@@ -105,6 +103,7 @@
 	},
 /obj/structure/closet/secure_closet/interdynefob/deckofficer_locker,
 /obj/item/circuitboard/machine/techfab/ip,
+/obj/item/circuitboard/computer/id_upgrader/ip,
 /turf/open/floor/wood,
 /area/ruin/interdyne_planetary_base/cargo/deck)
 "aw" = (
@@ -151,6 +150,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/machinery/computer/id_upgrader/ip{
+	dir = 1;
+	pixel_y = 3
+	},
 /turf/open/floor/wood,
 /area/ruin/interdyne_planetary_base/cargo/deck)
 "aA" = (
@@ -220,6 +223,9 @@
 /obj/machinery/light_switch/directional/east,
 /obj/item/bedsheet/rd/double,
 /obj/structure/bed/double,
+/obj/effect/mob_spawn/ghost_role/human/interdyne_planetary_base/deck_officer/ice{
+	dir = 4
+	},
 /turf/open/floor/carpet/royalblue,
 /area/ruin/interdyne_planetary_base/cargo/deck)
 "aO" = (
@@ -820,6 +826,8 @@
 /area/ruin/interdyne_planetary_base/cargo)
 "cl" = (
 /obj/structure/railing,
+/obj/structure/ore_box,
+/obj/item/toy/figure/prisoner,
 /turf/open/floor/iron/diagonal,
 /area/ruin/interdyne_planetary_base/cargo)
 "cm" = (
@@ -1210,7 +1218,7 @@
 "dl" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/box/white,
-/obj/structure/ore_box,
+/obj/effect/mob_spawn/ghost_role/robot/interdyne,
 /obj/machinery/button/door/directional/north{
 	id = "interdynewarehosue";
 	name = "window security button";
@@ -1449,7 +1457,7 @@
 	},
 /area/ruin/interdyne_planetary_base/cargo/ware)
 "dT" = (
-/obj/structure/ore_box,
+/obj/effect/mob_spawn/ghost_role/robot/interdyne,
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/iron/smooth_edge{
 	dir = 8
@@ -1553,8 +1561,7 @@
 /area/ruin/interdyne_planetary_base)
 "ek" = (
 /obj/effect/turf_decal/box/white,
-/obj/item/toy/figure/prisoner,
-/obj/structure/ore_box,
+/obj/effect/mob_spawn/ghost_role/robot/interdyne,
 /turf/open/floor/iron/smooth_edge{
 	dir = 8
 	},
@@ -2845,6 +2852,7 @@
 "hI" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/suit_storage_unit/syndicate/chameleon,
+/obj/machinery/suit_storage_unit/interdyne,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/main/vault)
 "hJ" = (
@@ -7390,6 +7398,10 @@
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/icemoon/underground/explored)
+"Qq" = (
+/obj/structure/ore_box,
+/turf/open/floor/iron/diagonal,
+/area/ruin/interdyne_planetary_base/cargo)
 "QK" = (
 /obj/structure/railing{
 	dir = 10
@@ -7513,7 +7525,7 @@
 /turf/open/floor/iron/smooth_large,
 /area/ruin/interdyne_planetary_base/main/dorms)
 "Wi" = (
-/obj/machinery/power/micro_reactor,
+/obj/machinery/power/micro_reactor/bapgm,
 /obj/structure/cable,
 /turf/open/floor/iron/submarine,
 /area/ruin/interdyne_planetary_base/eng)
@@ -7540,6 +7552,12 @@
 /obj/item/ammo_workbench_module/lethal_super/evil,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/main/vault)
+"WM" = (
+/obj/structure/ore_box,
+/turf/open/floor/plating/reinforced{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/icemoon/underground/explored)
 "WQ" = (
 /obj/structure/shipping_container/donk_co{
 	pixel_x = 6
@@ -8881,8 +8899,8 @@ aR
 aG
 bh
 by
-bN
-bN
+Qq
+Qq
 cl
 cE
 cz
@@ -9824,7 +9842,7 @@ LM
 CW
 rF
 rF
-rF
+WM
 PJ
 rF
 GW
@@ -9940,7 +9958,7 @@ ab
 xc
 rF
 rF
-rF
+WM
 rF
 rF
 rF

--- a/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1984.dmm
+++ b/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1984.dmm
@@ -1077,9 +1077,9 @@
 	},
 /area/ruin/interdyne_planetary_base/med/morgue)
 "jo" = (
-/obj/structure/ore_box,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light/cold/directional/south,
+/obj/effect/mob_spawn/ghost_role/robot/interdyne,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/cargo)
 "jp" = (
@@ -1919,6 +1919,7 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
+/obj/structure/ore_box,
 /turf/open/floor/iron/herringbone,
 /area/ruin/interdyne_planetary_base/cargo)
 "pT" = (
@@ -1929,7 +1930,7 @@
 /area/ruin/interdyne_planetary_base/eng)
 "pX" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/ore_box,
+/obj/effect/mob_spawn/ghost_role/robot/interdyne,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/cargo)
 "pZ" = (
@@ -4871,11 +4872,6 @@
 	},
 /turf/open/floor/engine/bz,
 /area/ruin/interdyne_planetary_base/science/xeno)
-"On" = (
-/obj/structure/ore_box,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark/textured_large,
-/area/ruin/interdyne_planetary_base/cargo)
 "Oo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -5216,6 +5212,7 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
+/obj/structure/ore_box,
 /turf/open/floor/iron/herringbone,
 /area/ruin/interdyne_planetary_base/cargo)
 "Rw" = (
@@ -5424,6 +5421,8 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
+/obj/structure/ore_box,
+/obj/structure/ore_box,
 /turf/open/floor/iron/herringbone,
 /area/ruin/interdyne_planetary_base/cargo)
 "SR" = (
@@ -7854,7 +7853,7 @@ Wf
 Qd
 pR
 pn
-On
+pX
 Ih
 uQ
 ql

--- a/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1984.dmm
+++ b/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1984.dmm
@@ -1479,6 +1479,7 @@
 /area/ruin/interdyne_planetary_base/med)
 "ml" = (
 /obj/structure/closet/secure_closet/interdynefob/deckofficer_locker,
+/obj/item/circuitboard/computer/id_upgrader/ip,
 /turf/open/floor/wood,
 /area/ruin/interdyne_planetary_base/cargo/deck)
 "mm" = (
@@ -2597,7 +2598,7 @@
 	req_access = list("syndicate")
 	},
 /obj/effect/turf_decal/delivery/white,
-/obj/machinery/suit_storage_unit/interdyne/nerfed,
+/obj/machinery/suit_storage_unit/interdyne,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/med)
 "vO" = (
@@ -3541,6 +3542,11 @@
 	dir = 9
 	},
 /obj/structure/table/wood,
+/obj/item/kirbyplants{
+	icon_state = "plant-29";
+	pixel_y = 11;
+	pixel_x = 6
+	},
 /turf/open/floor/iron/white,
 /area/ruin/interdyne_planetary_base/cargo/deck)
 "Dx" = (
@@ -3836,7 +3842,7 @@
 /area/ruin/interdyne_planetary_base)
 "Fh" = (
 /obj/structure/cable,
-/obj/machinery/power/micro_reactor,
+/obj/machinery/power/micro_reactor/bapgm,
 /turf/open/floor/engine,
 /area/ruin/interdyne_planetary_base/eng)
 "Fj" = (
@@ -4618,6 +4624,7 @@
 	name = "Interdyne Vault Camera";
 	c_tag = "Interdyne Vault Camera"
 	},
+/obj/machinery/announcement_system,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/main/vault)
 "Ma" = (
@@ -5140,10 +5147,10 @@
 "Qw" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/table/wood,
-/obj/item/kirbyplants{
-	icon_state = "plant-29";
-	pixel_y = 11;
-	pixel_x = 6
+/obj/machinery/computer/id_upgrader/ip{
+	dir = 8;
+	pixel_x = -2;
+	pixel_y = 3
 	},
 /turf/open/floor/wood,
 /area/ruin/interdyne_planetary_base/cargo/deck)
@@ -5742,16 +5749,19 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/syndicate/red/secretformula,
 /obj/item/circuitboard/computer/ghostpad/interdyne{
-	pixel_x = 2;
+	pixel_x = -4;
 	pixel_y = 2
 	},
 /obj/item/circuitboard/machine/ghostpad/interdyne{
-	pixel_x = 4;
+	pixel_x = -2;
 	pixel_y = 4
 	},
 /obj/item/circuitboard/computer/cargo/express/ghost/interdyne{
-	pixel_x = 6;
 	pixel_y = 6
+	},
+/obj/item/circuitboard/machine/protolathe/offstation{
+	pixel_y = 8;
+	pixel_x = 2
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/main/vault)

--- a/_maps/RandomRuins/SpaceRuins/nova/des_two1984.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/des_two1984.dmm
@@ -1540,6 +1540,7 @@
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner,
 /obj/machinery/light/cold/directional/south,
 /obj/machinery/light_switch/directional/south,
+/obj/effect/mob_spawn/ghost_role/robot/ds2,
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/nova/des_two/bridge)
 "gI" = (
@@ -3329,6 +3330,7 @@
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner,
 /obj/machinery/light/cold/directional/south,
 /obj/machinery/firealarm/directional/south,
+/obj/effect/mob_spawn/ghost_role/robot/ds2,
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/nova/des_two/bridge)
 "og" = (
@@ -3634,7 +3636,7 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/nova/des_two/engineering)
 "ps" = (
-/obj/machinery/computer/cryopod/interdyne/directional/west,
+/obj/machinery/computer/cryopod/directional/west,
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 8
@@ -4852,6 +4854,10 @@
 /area/ruin/space/has_grav/nova/des_two/security)
 "vr" = (
 /obj/effect/mob_spawn/ghost_role/human/ds2/syndicate_command/masteratarms,
+/obj/machinery/suit_storage_unit/syndicate/deepspace{
+	density = 0;
+	pixel_y = 32
+	},
 /turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/nova/des_two/security)
 "vt" = (
@@ -4870,7 +4876,6 @@
 	pixel_y = -4
 	},
 /obj/item/ammo_workbench_module/lethal_super/evil,
-/obj/item/ammo_workbench_reboot,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/nova/des_two/security/armory)
 "vu" = (
@@ -5637,6 +5642,7 @@
 /obj/item/binoculars,
 /obj/item/wrench/bolter,
 /obj/item/storage/toolbox/syndicate,
+/obj/item/binoculars,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/nova/des_two/bridge/cl)
 "zl" = (
@@ -6259,6 +6265,7 @@
 /obj/item/circuitboard/computer/id_upgrader/ds,
 /obj/item/storage/toolbox/syndicate,
 /obj/item/circuitboard/machine/techfab/ds,
+/obj/item/binoculars,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/nova/des_two/bridge/admiral)
 "Ce" = (
@@ -7608,6 +7615,7 @@
 /obj/item/wrench/bolter,
 /obj/item/clothing/gloves/kaza_ruk/combatglovesplus/maa,
 /obj/item/storage/toolbox/syndicate,
+/obj/item/binoculars,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/nova/des_two/security)
 "If" = (
@@ -9024,7 +9032,7 @@
 	color = "#00ff00";
 	name = "green"
 	},
-/obj/machinery/computer/cryopod/interdyne/directional/east,
+/obj/machinery/computer/cryopod/directional/east,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/nova/des_two/security/prison)
 "OU" = (
@@ -9455,6 +9463,7 @@
 	dir = 1
 	},
 /obj/machinery/light/cold/directional/north,
+/obj/effect/mob_spawn/ghost_role/robot/ds2,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -9745,6 +9754,7 @@
 	network = list("ds2")
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/item/inducer/syndicate,
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/nova/des_two/bridge)
 "Sg" = (

--- a/modular_ss220/modules/rolesedit/code/syndicate_roles/interdyne.dm
+++ b/modular_ss220/modules/rolesedit/code/syndicate_roles/interdyne.dm
@@ -86,3 +86,22 @@
 
 /datum/outfit/lavaland_syndicate/shaftminer/deckofficer
 	role_job = /datum/job/interdyne_planetary_base/command
+
+//qm console
+/obj/machinery/computer/id_upgrader/ip
+	name = "interdyne access upgrader laptop"
+	desc = "A compact console meant to allow modifications to IDs. This one made by interdyne pharmaceutics and add IP access."
+	icon = 'icons/obj/machines/computer.dmi'
+	density = FALSE
+	icon_state = "laptop"
+	icon_screen = "medlaptop"
+	icon_keyboard = "laptop_key"
+	pass_flags = PASSTABLE
+	projectiles_pass_chance = 100
+	circuit = /obj/item/circuitboard/computer/id_upgrader/ip
+	access_to_give = list(ACCESS_SYNDICATE_IP)
+
+/obj/item/circuitboard/computer/id_upgrader/ip
+	name = "interdyne access upgrader console circuit"
+	greyscale_colors = CIRCUIT_COLOR_SECURITY
+	build_path = /obj/machinery/computer/id_upgrader/ip


### PR DESCRIPTION
## Описание
Добавил ноут улучшения доступа(добавляет доступ интердайна) стоит у офицера интердайна
Обновил карты дс2 и интердайна обновив частично карту до уровня оффов

## Changelog

:cl:
add: Added IP id upgrade machine
map: updated ds 2 and interdyne - replaced generators with less powerfull version, replaced chameleon mod on ice ip with interdyne mod. chameleon mod now in Deck Officer room. Added borg spawners
/:cl:


- [x] Проверено на локалке
