### PR TITLE
balance: .40 Sol bullets old stats

### DIFF
--- a/modular_ss220/modules/balance-1984/old_ballistics_damage/rifle.dm
+++ b/modular_ss220/modules/balance-1984/old_ballistics_damage/rifle.dm
@@ -1,5 +1,7 @@
 /obj/projectile/bullet/c40sol
 	damage = 35
+	wound_bonus = 0
+	exposed_wound_bonus = 0
 
 /obj/projectile/bullet/c40sol/fragmentation
 	damage = 15


### PR DESCRIPTION
Дополнение к #540 (balance: Revert "a heavy duty rebalance of most station ballistics, raising their time to down by roughly around 35%, evening out to around 3-4s to down, instead of 2-2.5s")

## Changelog

:cl:
balance: .40 Sol bullets (and subtypes) damage against unarmored targets 10 => 0 and bonus to wounds 5 => 0, as it was before
/:cl:
