### PR TITLE
balance: all arrows weak against armor

### DIFF
--- a/modular_ss220/modules/weapons_addon/code/tribal/arrow.dm
+++ b/modular_ss220/modules/weapons_addon/code/tribal/arrow.dm
@@ -1,0 +1,2 @@
+/obj/projectile/bullet/arrow
+	weak_against_armour = TRUE

--- a/modular_ss220/modules/weapons_addon/code/tribal/arrow.dm
+++ b/modular_ss220/modules/weapons_addon/code/tribal/arrow.dm
@@ -1,2 +1,2 @@
-/obj/projectile/bullet/arrow
+/obj/item/ammo_casing/arrow
 	weak_against_armour = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9625,6 +9625,7 @@
 #include "modular_ss220\modules\weapons_addon\code\qmgun.dm"
 #include "modular_ss220\modules\weapons_addon\code\solguns\magazines.dm"
 #include "modular_ss220\modules\weapons_addon\code\solguns\pistol.dm"
+#include "modular_ss220\modules\weapons_addon\code\tribal\arrow.dm"
 #include "modular_ss220\modules\enhanced_messaging\nttc_globals.dm"
 #include "modular_ss220\modules\enhanced_messaging\code\messaging_config.dm"
 #include "modular_ss220\modules\enhanced_messaging\code\nttc_configuration.dm"


### PR DESCRIPTION
## Changelog

:cl:
balance: Arrows are now weak against armor (armor is doubled when calculating damage, but it's done after armor penetration). Example: nuclear operative MOD received damage from arrow: 25 => 5, security officer with default loadout 36 => 22.
/:cl:

****
- [x] Проверено на локалке
