### PR TITLE
balance: revert "Zaibas longarms decrease in recoil of 50%"

### DIFF
--- a/modular_ss220/modules/balance-1984/old_pulse_recoil/pulse_rifle.dm
+++ b/modular_ss220/modules/balance-1984/old_pulse_recoil/pulse_rifle.dm
@@ -1,0 +1,2 @@
+/obj/item/gun/ballistic/automatic/pulse_rifle
+	recoil = 0.5

--- a/modular_ss220/modules/balance-1984/old_pulse_recoil/pulse_sniper.dm
+++ b/modular_ss220/modules/balance-1984/old_pulse_recoil/pulse_sniper.dm
@@ -1,0 +1,2 @@
+/obj/item/gun/ballistic/rifle/pulse_sniper
+	recoil = 1

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9714,6 +9714,8 @@
 #include "modular_ss220\modules\balance-1984\old_ballistics_damage\submachinegun.dm"
 #include "modular_ss220\modules\balance-1984\holster_holdables\sec_clothing_overrides.dm"
 #include "modular_ss220\modules\balance-1984\weakened_mmr\rifle.dm"
+#include "modular_ss220\modules\balance-1984\old_pulse_recoil\pulse_sniper.dm"
+#include "modular_ss220\modules\balance-1984\old_pulse_recoil\pulse_rifle.dm"
 #include "modular_ss220\modules\infinite_access_slots\infinite_access_slots_config.dm"
 #include "modular_ss220\modules\infinite_access_slots\cards_ids.dm"
 #include "modular_ss220\modules\access_console_buttons\card.dm"


### PR DESCRIPTION
## Changelog

:cl:
balance: Revert "Discovery that the foregrips and handguards on the Zaibas longarms are not decorative has led to a decrease in recoil of 50% (half)"
/:cl:
