### PR TITLE
map: ds2ip maps update 22012026

### DIFF
--- a/_maps/RandomRuins/IceRuins/nova/icemoon_underground_interdyne_base1984.dmm
+++ b/_maps/RandomRuins/IceRuins/nova/icemoon_underground_interdyne_base1984.dmm
@@ -2677,7 +2677,6 @@
 /obj/machinery/turretid{
 	name = "Base turret controls";
 	desc = "Used to control the base's automated defenses.";
-	icon_state = "control_kill";
 	dir = 1;
 	pixel_y = 30;
 	req_access = list("syndicate");

--- a/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1984.dmm
+++ b/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1984.dmm
@@ -3506,7 +3506,6 @@
 /obj/machinery/turretid{
 	name = "Base turret controls";
 	desc = "Used to control the base's automated defenses.";
-	icon_state = "control_kill";
 	dir = 1;
 	pixel_y = 30;
 	req_access = list("syndicate");

--- a/_maps/RandomRuins/SpaceRuins/nova/des_two1984.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/des_two1984.dmm
@@ -9505,12 +9505,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/nova/des_two)
-"QY" = (
-/obj/machinery/door/window/survival_pod/left/directional/north{
-	req_access = list("syndicate_deepspace")
-	},
-/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
-/area/ruin/space/has_grav/nova/des_two/security)
 "Rb" = (
 /obj/machinery/chem_master/condimaster{
 	name = "BrewMaster 3000"
@@ -12573,7 +12567,7 @@ yu
 eb
 Xh
 Xh
-QY
+Xh
 Xh
 Xh
 Tt

--- a/_maps/RandomRuins/SpaceRuins/nova/des_two1984.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/des_two1984.dmm
@@ -3919,8 +3919,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
-/obj/structure/frame/machine/secured,
-/obj/item/circuitboard/machine/rdserver/deepspace,
+/obj/machinery/rnd/server/deepspace,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/nova/des_two/research)
 "qN" = (

--- a/_maps/RandomRuins/SpaceRuins/nova/des_two1984.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/des_two1984.dmm
@@ -3590,7 +3590,7 @@
 	desc = "A brick of stimulants meant for use by Tiger Cooperative agents. It seems this one's just a brittle block of heroin.";
 	name = "Tiger Coop stimulant brick"
 	},
-/obj/item/circuitboard/machine/rdserver/interdyne_ds2,
+/obj/item/circuitboard/machine/rdserver/deepspace,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/nova/des_two/bridge/vault)
 "pk" = (
@@ -3853,10 +3853,7 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/nova/des_two/halls)
 "qw" = (
-/obj/machinery/suit_storage_unit/syndicate/chameleon{
-	name = "suit storage unit";
-	req_access = list("syndicate_leader")
-	},
+/obj/machinery/suit_storage_unit/syndicate/deepspace,
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
@@ -3922,7 +3919,8 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
-/obj/machinery/rnd/server/interdyne_ds2,
+/obj/structure/frame/machine/secured,
+/obj/item/circuitboard/machine/rdserver/deepspace,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/nova/des_two/research)
 "qN" = (
@@ -5219,7 +5217,6 @@
 	ailock = 1;
 	control_area = "/area/ruin/space/has_grav/nova/des_two/bridge/vault";
 	dir = 1;
-	icon_state = "control_kill";
 	lethal = 1;
 	name = "DS2 turret controls";
 	pixel_x = -30;
@@ -6089,10 +6086,7 @@
 /turf/template_noop,
 /area/template_noop)
 "Bu" = (
-/obj/machinery/suit_storage_unit/syndicate/chameleon{
-	name = "suit storage unit";
-	req_access = list("syndicate_leader")
-	},
+/obj/machinery/suit_storage_unit/syndicate/deepspace,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/mapping_helpers/apc/syndicate_access,
 /obj/structure/cable,
@@ -7806,6 +7800,13 @@
 /obj/item/reagent_containers/cup/maunamug{
 	pixel_x = 4
 	},
+/obj/machinery/suit_storage_unit{
+	mask_type = /obj/item/clothing/mask/gas/syndicate;
+	mod_type = /obj/item/mod/control/pre_equipped/traitor_elite;
+	storage_type = /obj/item/tank/jetpack/harness;
+	density = 0;
+	pixel_x = 28
+	},
 /turf/open/floor/carpet/donk,
 /area/ruin/space/has_grav/nova/des_two/bridge/cl)
 "IQ" = (
@@ -7836,11 +7837,7 @@
 /obj/structure/window/reinforced/survival_pod{
 	dir = 10
 	},
-/obj/machinery/suit_storage_unit{
-	mask_type = /obj/item/clothing/mask/gas/syndicate;
-	mod_type = /obj/item/mod/control/pre_equipped/traitor_elite;
-	storage_type = /obj/item/tank/jetpack/harness
-	},
+/obj/machinery/suit_storage_unit/syndicate/deepspace_admiral,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/nova/des_two/bridge/admiral)
 "Ja" = (


### PR DESCRIPTION
## Описание

Заменил синди моды в оружейке дс 2 на киберсановые
заменил элитный мод синдиката на адмиральскую модель адмиралу ДСа
выдал представителю(Liason) элитный мод что был у адмирала до этого
Починил текстуры контроллеров турелей(теперь они имеют оверлеи, так что текстура вернулась в 'исходный' вариант

## Changelog

:cl:
map: replaced syndicate modsuits with cybersun ones at DS-2 armory
map: DS-2 Admiral now get their own cybersun elite modsuit, while Liason get the basic elite modsuit
fix: turret controllers icon at interdyne and DS-2 maps fixed
/:cl:


- [x] Проверено на локалке