### PR TITLE
fix: sleep is now properly expiring for non-player mobs

### DIFF
--- a/modular_nova/master_files/code/modules/sleep/code/datums/status_effects/_status_effect.dm
+++ b/modular_nova/master_files/code/modules/sleep/code/datums/status_effects/_status_effect.dm
@@ -12,4 +12,9 @@
 /datum/status_effect/proc/disable_expiry()
 	SIGNAL_HANDLER
 
+	// SS1984 ADDITION START
+	if (owner.lastclienttime == 0) // if wasn't controlled by player ever, then lastclienttime would be 0
+		return
+	// SS1984 ADDITION END
+
 	pause_expiry = TRUE

--- a/modular_nova/master_files/code/modules/sleep/code/datums/status_effects/debuffs/debuffs.dm
+++ b/modular_nova/master_files/code/modules/sleep/code/datums/status_effects/debuffs/debuffs.dm
@@ -24,7 +24,7 @@
 /datum/status_effect/incapacitating/sleeping/on_creation(mob/living/new_owner, set_duration, is_voluntary = FALSE)
 	voluntary = is_voluntary
 	// Sleep until the client logs-in again
-	if(isnull(new_owner.client))
+	if(isnull(new_owner.client) && new_owner.lastclienttime > 0) // SS1984 EDIT, original: if(isnull(new_owner.client))
 		pause_expiry = TRUE
 	// Hide sleep duration if permanent
 	if(set_duration == STATUS_EFFECT_PERMANENT)


### PR DESCRIPTION
## Changelog

:cl:
fix: sleep is now properly expiring for non-player mobs
/:cl:

****
- [x] Проверено на локалке
