### PR TITLE
add: ds2 and interdyne now have syndicate techweb node researched

### DIFF
--- a/modular_ss220/modules/rolesedit/code/syndicate_roles/deepspace/rnd.dm
+++ b/modular_ss220/modules/rolesedit/code/syndicate_roles/deepspace/rnd.dm
@@ -4,6 +4,10 @@
 	organization = "Syndicate"
 	should_generate_points = TRUE
 
+/datum/techweb/deepspace/New()
+	. = ..()
+	research_node_id(TECHWEB_NODE_SYNDICATE_BASIC, TRUE, TRUE, FALSE)
+
 //server
 /obj/machinery/rnd/server/deepspace
 	name = "\improper Syndicate R&D Server"


### PR DESCRIPTION
По сути фикс, но все же раньше у них такого вроде как не было

## Скриншоты

<img width="632" height="720" alt="image" src="https://github.com/user-attachments/assets/6296c54a-cd48-4b0c-b462-6b35282749cd" />

## Changelog

:cl:
add: DS-2 (and interdyne, as they use same techweb) now starts with "Illegal Technology" node, which enables illegal researches.
/:cl:

****
- [x] Проверено на локалке