### PR TITLE
spellcheck: chav mutation ending localized

### DIFF
--- a/code/datums/mutations/speech.dm
+++ b/code/datums/mutations/speech.dm
@@ -194,7 +194,7 @@
 
 /datum/mutation/chav/New(datum/mutation/copymut)
 	. = ..()
-	AddComponent(/datum/component/speechmod, replacements = strings("chav_replacement.json", "chav"), end_string = ", mate", end_string_chance = 30)
+	AddComponent(/datum/component/speechmod, replacements = strings("chav_replacement.json", "chav"), end_string = ", товарищ", end_string_chance = 30) // SS1984 EDIT, original: AddComponent(/datum/component/speechmod, replacements = strings("chav_replacement.json", "chav"), end_string = ", mate", end_string_chance = 30)
 
 /datum/mutation/elvis
 	name = "Elvis"


### PR DESCRIPTION
## Changelog

:cl:
spellcheck: chav mutation message ending "mate" localized
/:cl:

****
- [x] Проверено на локалке
