### PR TITLE
balance: Revert self-charging for laser weaponry

### DIFF
--- a/modular_nova/modules/modular_weapons/code/overrides/energy_self_charge.dm
+++ b/modular_nova/modules/modular_weapons/code/overrides/energy_self_charge.dm
@@ -2,6 +2,8 @@
 
 #define CHARGE_MESSAGE "Equipped with a trickle-charge microcell. Regains a shot every couple of minutes without external power. Dont expect it to keep up with heavy use."
 
+/* SS1984 REMOVAL START (non modular because of examine)
+
 // disabler
 /obj/item/gun/energy/disabler
 	selfcharge = TRUE
@@ -63,4 +65,5 @@
 	. = ..()
 	. += span_notice(CHARGE_MESSAGE)
 
+SS1984 REMOVAL END*/
 #undef CHARGE_MESSAGE


### PR DESCRIPTION
## Changelog

:cl:
balance: Revert "Gives small energy arms, and the SC2 derivates, self recharging capabilities, 10% of their charge per 15 seconds. Gives large energy arms a crank based recharge, 8 seconds of cranking (which can be done moving or shooting!) for 25% of the charge, compared to a t1 recharger that takes 20 seconds to a full charge.", for all laser-weaponry (except those, that have it on TG)
/:cl:

****
- [x] Проверено на локалке
