### PR TITLE
balance: Energy weaponry capacity back to TG

### DIFF
--- a/modular_ss220/modules/balance-1984/old_egun_capacity/energy.dm
+++ b/modular_ss220/modules/balance-1984/old_egun_capacity/energy.dm
@@ -1,0 +1,26 @@
+/obj/item/ammo_casing/energy/laser
+	e_cost = LASER_SHOTS(12, STANDARD_CELL_CHARGE)
+
+/obj/item/ammo_casing/energy/laser/hos
+	e_cost = LASER_SHOTS(12, STANDARD_CELL_CHARGE * 1.2)
+
+/obj/item/ammo_casing/energy/disabler/hos
+	e_cost = LASER_SHOTS(20, STANDARD_CELL_CHARGE * 1.2)
+
+/obj/item/ammo_casing/energy/ion/hos
+	e_cost = LASER_SHOTS(4, STANDARD_CELL_CHARGE * 1.2)
+
+/obj/item/ammo_casing/energy/laser/hellfire
+	e_cost = LASER_SHOTS(10, STANDARD_CELL_CHARGE)
+
+/obj/item/ammo_casing/energy/lasergun
+	e_cost = LASER_SHOTS(16, STANDARD_CELL_CHARGE)
+
+/obj/item/ammo_casing/energy/lasergun/pistol
+	e_cost = LASER_SHOTS(10, STANDARD_CELL_CHARGE)
+
+/obj/item/ammo_casing/energy/lasergun/carbine
+	e_cost = LASER_SHOTS(26, STANDARD_CELL_CHARGE)
+
+/obj/item/stock_parts/power_store/cell/mini_egun
+	maxcharge = STANDARD_CELL_CHARGE * 0.6

--- a/modular_ss220/modules/balance-1984/old_hos_gun/energy.dm
+++ b/modular_ss220/modules/balance-1984/old_hos_gun/energy.dm
@@ -1,8 +1,0 @@
-/obj/item/ammo_casing/energy/laser/hos
-	e_cost = LASER_SHOTS(12, STANDARD_CELL_CHARGE * 1.2)
-
-/obj/item/ammo_casing/energy/disabler/hos
-	e_cost = LASER_SHOTS(20, STANDARD_CELL_CHARGE * 1.2)
-
-/obj/item/ammo_casing/energy/ion/hos
-	e_cost = LASER_SHOTS(4, STANDARD_CELL_CHARGE * 1.2)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9770,7 +9770,7 @@
 #include "modular_ss220\modules\balance-1984\battlerifle_tg\automatic.dm"
 #include "modular_ss220\modules\balance-1984\max_staminadamage_tg\living_defines.dm"
 #include "modular_ss220\modules\balance-1984\drones_restrictions\drone_dispenser.dm"
-#include "modular_ss220\modules\balance-1984\old_hos_gun\energy.dm"
+#include "modular_ss220\modules\balance-1984\old_egun_capacity\energy.dm"
 #include "modular_ss220\modules\balance-1984\vehicle_speed\_vehicle.dm"
 #include "modular_ss220\modules\balance-1984\old_ballistics_damage\ammo.dm"
 #include "modular_ss220\modules\balance-1984\old_ballistics_damage\pistol.dm"


### PR DESCRIPTION
## Changelog

:cl:
balance: Revert "Laser and disabler cell costs have been equalized for energy guns and mini energy guns, meaning they both fire the same amount of lasers or disablers."
balance: Revert "Laser guns now get 25 shots per charge. Energy guns get 20 shots per charge of either laser or disabler. Hellfires get 20 shots per charge. Mini energy guns get 15 shots per charge. Blueshield's hellfire gets 25 shots per charge.
image: Blueshields who choose to use their hellfire gun get a blue one. Congratulations, blueshields."
/:cl:
