### PR TITLE
balance: NTR no longer count as enemy for dynamic

### DIFF
--- a/modular_ss220/modules/dynamic_tweaks/dynamic_ruleset.dm
+++ b/modular_ss220/modules/dynamic_tweaks/dynamic_ruleset.dm
@@ -18,7 +18,6 @@
 		JOB_WARDEN,
 		JOB_CORRECTIONS_OFFICER,
 		JOB_BLUESHIELD,
-		JOB_NT_REP,
 	)
 	var/can_always_be_selected = FALSE // used primary for admin-forced, basically just skips entirely proc: can_be_selected()
 


### PR DESCRIPTION
## Changelog

:cl:
balance: Nanotrasen Consultant no longer considered as "enemy" for dynamic (not treated same way as 1 security required for most rulesets)
/:cl:
