### PR TITLE
balance: obsessed now require 3 security to apply for security/ntr

### DIFF
--- a/modular_ss220/modules/dynamic_tweaks/rulesets/dynamic_ruleset_midround.dm
+++ b/modular_ss220/modules/dynamic_tweaks/rulesets/dynamic_ruleset_midround.dm
@@ -61,7 +61,7 @@
 
 /datum/dynamic_ruleset/midround/from_living/obsesed/collect_candidates()
 	. = ..()
-	last_valid_enemies_count = get_all_valid_enemies_for_midround_latejoin() // cache it each time at this stage
+	last_valid_enemies_count = length(get_all_valid_enemies_for_midround_latejoin()) // cache it each time at this stage
 
 /datum/dynamic_ruleset/midround/from_living/obsesed/is_valid_candidate(mob/candidate, client/candidate_client)
 	. = ..()
@@ -69,7 +69,10 @@
 		return .
 
 	var/jobtitle = "[candidate.mind.assigned_role.title]"
-	if (jobtitle in enemy_roles || jobtitle in apply_security_amount_for_extra_roles)
-		 // if at least 3 - then true, otherwise false
+	if ((jobtitle in enemy_roles) || (jobtitle in apply_security_amount_for_extra_roles))
+		// if at least 3 - then true, otherwise false
 		return !(last_valid_enemies_count < required_security_to_receive_security_obsession)
 	return .
+
+/datum/dynamic_ruleset/midround/from_living/obsesed/get_blacklisted_roles()
+	return get_always_blacklisted_roles() // SKIPS CONFIG BLACKLISTED ROLES (such as security, because they are protected)

--- a/modular_ss220/modules/dynamic_tweaks/rulesets/dynamic_ruleset_midround.dm
+++ b/modular_ss220/modules/dynamic_tweaks/rulesets/dynamic_ruleset_midround.dm
@@ -51,3 +51,25 @@
 		DYNAMIC_TIER_MEDIUMHIGH = 3,
 		DYNAMIC_TIER_HIGH = 6,
 	)
+
+/datum/dynamic_ruleset/midround/from_living/obsesed
+	var/required_security_to_receive_security_obsession = 3
+	VAR_PRIVATE/last_valid_enemies_count = 0 // required to run expensive operations only once, it's "last" in terms of variable name, but actually usage as if it's current now
+	var/list/apply_security_amount_for_extra_roles = list(
+		JOB_NT_REP,
+	)
+
+/datum/dynamic_ruleset/midround/from_living/obsesed/collect_candidates()
+	. = ..()
+	last_valid_enemies_count = get_all_valid_enemies_for_midround_latejoin() // cache it each time at this stage
+
+/datum/dynamic_ruleset/midround/from_living/obsesed/is_valid_candidate(mob/candidate, client/candidate_client)
+	. = ..()
+	if (!.)
+		return .
+
+	var/jobtitle = "[candidate.mind.assigned_role.title]"
+	if (jobtitle in enemy_roles || jobtitle in apply_security_amount_for_extra_roles)
+		 // if at least 3 - then true, otherwise false
+		return !(last_valid_enemies_count < required_security_to_receive_security_obsession)
+	return .


### PR DESCRIPTION
## Changelog

:cl:
balance: Obsessed ruleset now require 3 enemy roles (such as security) to be applyable for security/NTR as candidates. Still require 1 enemy, if rolling for other candidates.
/:cl:

****
- [x] Проверено на локалке