### PR TITLE
balance: slimepeople can split again

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -16,7 +16,7 @@
 #define BLOOD_VOLUME_MAX_LETHAL 2150
 #define BLOOD_VOLUME_EXCESS 2100
 #define BLOOD_VOLUME_MAXIMUM 1000 // NOVA EDIT - Blood volume balancing (mainly for Hemophages as nobody else really goes much above regular blood volume) - ORIGINAL VALUE: 2000
-#define BLOOD_VOLUME_SLIME_SPLIT 1120
+#define BLOOD_VOLUME_SLIME_SPLIT BLOOD_VOLUME_MAXIMUM * 0.95 // SS1984 EDIT, original: #define BLOOD_VOLUME_SLIME_SPLIT 1120
 #define BLOOD_VOLUME_NORMAL 560
 #define BLOOD_VOLUME_SAFE (BLOOD_VOLUME_NORMAL * (1 - 0.15)) // Latter number is percentage of blood lost, for readability!
 #define BLOOD_VOLUME_OKAY (BLOOD_VOLUME_NORMAL * (1 - 0.30))


### PR DESCRIPTION
## P.S.

Для того, чтоб набрать 950 cl желе (крови), нужно набрать от 450 насыщения (с еды), после этого желе начнет копиться каждую секунду до 1000 (ждать примерно 5 минут). При 950 (примерно 169%) кнопка станет доступна.

## Changelog

:cl:
balance: Required amount of slime jelly to split body for slimepeople: 1120 -> 950 (maximum jelly is 1000)
/:cl:

****
- [x] Проверено на локалке