### PR TITLE
map: ip and ds-2 update 07032026

### DIFF
--- a/_maps/RandomRuins/IceRuins/nova/icemoon_underground_interdyne_base1984.dmm
+++ b/_maps/RandomRuins/IceRuins/nova/icemoon_underground_interdyne_base1984.dmm
@@ -12,7 +12,7 @@
 "ae" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 9;
-	faction = list("Syndicate","neutral")
+	faction = list("Syndicate DS-2 Crew","Syndicate","Interdyne Lavaland Personnel","neutral")
 	},
 /turf/closed/wall/r_wall/plastitanium/syndicate{
 	fixed_underlay = list(icon='icons/turf/snow.dmi', icon_state="snow")
@@ -363,7 +363,7 @@
 "bk" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 5;
-	faction = list("Syndicate","neutral")
+	faction = list("Syndicate DS-2 Crew","Syndicate","Interdyne Lavaland Personnel","neutral")
 	},
 /turf/closed/wall/r_wall/plastitanium/syndicate{
 	fixed_underlay = list(icon='icons/turf/snow.dmi', icon_state="snow")
@@ -1561,7 +1561,7 @@
 "ej" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 10;
-	faction = list("Syndicate","neutral")
+	faction = list("Syndicate DS-2 Crew","Syndicate","Interdyne Lavaland Personnel","neutral")
 	},
 /turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/ruin/interdyne_planetary_base)
@@ -2729,7 +2729,7 @@
 "ho" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 6;
-	faction = list("Syndicate","neutral")
+	faction = list("Syndicate DS-2 Crew","Syndicate","Interdyne Lavaland Personnel","neutral")
 	},
 /turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/ruin/interdyne_planetary_base)
@@ -4359,7 +4359,7 @@
 "ln" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 10;
-	faction = list("Syndicate","neutral")
+	faction = list("Syndicate DS-2 Crew","Syndicate","Interdyne Lavaland Personnel","neutral")
 	},
 /turf/closed/wall/r_wall/plastitanium/syndicate{
 	fixed_underlay = list(icon='icons/turf/snow.dmi', icon_state="snow")
@@ -4368,7 +4368,7 @@
 "lo" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 6;
-	faction = list("Syndicate","neutral")
+	faction = list("Syndicate DS-2 Crew","Syndicate","Interdyne Lavaland Personnel","neutral")
 	},
 /turf/closed/wall/r_wall/plastitanium/syndicate{
 	fixed_underlay = list(icon='icons/turf/snow.dmi', icon_state="snow")
@@ -6897,7 +6897,7 @@
 "ua" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 5;
-	faction = list("Syndicate","neutral")
+	faction = list("Syndicate DS-2 Crew","Syndicate","Interdyne Lavaland Personnel","neutral")
 	},
 /turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
 /area/ruin/interdyne_planetary_base)
@@ -7008,7 +7008,7 @@
 "Ak" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 9;
-	faction = list("Syndicate","neutral")
+	faction = list("Syndicate DS-2 Crew","Syndicate","Interdyne Lavaland Personnel","neutral")
 	},
 /turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
 /area/ruin/interdyne_planetary_base)
@@ -7580,7 +7580,7 @@
 "Wm" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 9;
-	faction = list("Syndicate","neutral")
+	faction = list("Syndicate DS-2 Crew","Syndicate","Interdyne Lavaland Personnel","neutral")
 	},
 /obj/effect/baseturf_helper/reinforced_plating,
 /obj/effect/baseturf_helper/reinforced_plating/ceiling,

--- a/_maps/RandomRuins/IceRuins/nova/icemoon_underground_interdyne_base1984.dmm
+++ b/_maps/RandomRuins/IceRuins/nova/icemoon_underground_interdyne_base1984.dmm
@@ -2684,7 +2684,6 @@
 	control_area = "/area/ruin/interdyne_planetary_base";
 	ailock = 1
 	},
-/obj/item/folder/syndicate/red/secretformula,
 /obj/item/circuitboard/computer/ghostpad/interdyne{
 	pixel_x = 2;
 	pixel_y = 2
@@ -2697,6 +2696,8 @@
 	pixel_x = 6;
 	pixel_y = 6
 	},
+/obj/structure/rack,
+/obj/item/flatpack/ammo_workbench,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/main/vault)
 "hi" = (
@@ -7152,7 +7153,7 @@
 /area/icemoon/underground/explored)
 "Fi" = (
 /obj/machinery/light/small/directional/west,
-/obj/item/flatpack/ammo_workbench,
+/obj/machinery/announcement_system,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/main/vault)
 "FH" = (
@@ -7629,6 +7630,7 @@
 /obj/item/clothing/mask/gas/syndicate,
 /obj/item/mod/control/pre_equipped/nuclear/chameleon,
 /obj/item/tank/jetpack/harness,
+/obj/item/folder/syndicate/red/secretformula,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/main/vault)
 "WZ" = (

--- a/_maps/RandomRuins/IceRuins/nova/icemoon_underground_interdyne_base1984.dmm
+++ b/_maps/RandomRuins/IceRuins/nova/icemoon_underground_interdyne_base1984.dmm
@@ -42,7 +42,7 @@
 /area/ruin/interdyne_planetary_base/cargo)
 "aj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/suit_storage_unit/syndicate/chameleon,
+/obj/machinery/suit_storage_unit/interdyne,
 /turf/open/floor/wood,
 /area/ruin/interdyne_planetary_base/cargo/deck)
 "ak" = (
@@ -2865,7 +2865,6 @@
 /area/ruin/interdyne_planetary_base/main)
 "hI" = (
 /obj/machinery/light/small/directional/east,
-/obj/machinery/suit_storage_unit/syndicate/chameleon,
 /obj/machinery/suit_storage_unit/interdyne,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/main/vault)
@@ -7627,6 +7626,9 @@
 /obj/item/suppressor,
 /obj/item/toy/redbutton,
 /obj/item/folder/syndicate/mining,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/mod/control/pre_equipped/nuclear/chameleon,
+/obj/item/tank/jetpack/harness,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/main/vault)
 "WZ" = (

--- a/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1984.dmm
+++ b/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1984.dmm
@@ -164,7 +164,7 @@
 /area/ruin/interdyne_planetary_base/main)
 "bs" = (
 /obj/machinery/porta_turret/syndicate{
-	faction = list("Syndicate","neutral")
+	faction = list("Syndicate DS-2 Crew","Syndicate","Interdyne Lavaland Personnel","neutral")
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ruin/interdyne_planetary_base)
@@ -1031,7 +1031,7 @@
 /area/lavaland/surface/outdoors)
 "jb" = (
 /obj/machinery/porta_turret/syndicate{
-	faction = list("Syndicate","neutral");
+	faction = list("Syndicate DS-2 Crew","Syndicate","Interdyne Lavaland Personnel","neutral");
 	dir = 8
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -1223,6 +1223,9 @@
 	},
 /obj/item/bedsheet/brown/double{
 	dir = 1
+	},
+/obj/effect/mob_spawn/ghost_role/human/interdyne_planetary_base/deck_officer{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/ruin/interdyne_planetary_base/cargo/deck)
@@ -2209,7 +2212,7 @@
 "su" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 4;
-	faction = list("Syndicate","neutral")
+	faction = list("Syndicate DS-2 Crew","Syndicate","Interdyne Lavaland Personnel","neutral")
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/interdyne_planetary_base)
@@ -3403,9 +3406,7 @@
 /turf/open/floor/iron/textured_large,
 /area/ruin/interdyne_planetary_base/main)
 "Cq" = (
-/obj/effect/mob_spawn/ghost_role/human/interdyne_planetary_base/deck_officer{
-	dir = 8
-	},
+/obj/machinery/suit_storage_unit/interdyne,
 /turf/open/floor/wood,
 /area/ruin/interdyne_planetary_base/cargo/deck)
 "Cr" = (
@@ -5171,7 +5172,7 @@
 "QD" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 8;
-	faction = list("Syndicate","neutral")
+	faction = list("Syndicate DS-2 Crew","Syndicate","Interdyne Lavaland Personnel","neutral")
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ruin/interdyne_planetary_base)
@@ -6310,7 +6311,7 @@
 "Ys" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 1;
-	faction = list("Syndicate","neutral")
+	faction = list("Syndicate DS-2 Crew","Syndicate","Interdyne Lavaland Personnel","neutral")
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ruin/interdyne_planetary_base)

--- a/_maps/RandomRuins/SpaceRuins/nova/des_two1984.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/des_two1984.dmm
@@ -3561,6 +3561,10 @@
 	},
 /turf/open/floor/iron/pool,
 /area/ruin/space/has_grav/nova/des_two/engineering)
+"pc" = (
+/obj/machinery/announcement_system,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/nova/des_two/engineering)
 "pf" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/iron/dark/smooth_large,
@@ -12625,7 +12629,7 @@ ST
 Ig
 yl
 Tt
-IE
+pc
 Tt
 vV
 Tt

--- a/_maps/RandomRuins/SpaceRuins/nova/des_two1984.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/des_two1984.dmm
@@ -198,7 +198,7 @@
 "aW" = (
 /obj/machinery/porta_turret/syndicate/energy{
 	dir = 6;
-	faction = list("Syndicate DS-2 Crew","Interdyne Lavaland Personnel")
+	faction = list("Syndicate DS-2 Crew","Syndicate","Interdyne Lavaland Personnel")
 	},
 /turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
 /area/ruin/space/has_grav/nova/des_two/bridge/vault)
@@ -3282,7 +3282,7 @@
 "nO" = (
 /obj/machinery/porta_turret/syndicate/energy{
 	dir = 9;
-	faction = list("Syndicate DS-2 Crew","Interdyne Lavaland Personnel")
+	faction = list("Syndicate DS-2 Crew","Syndicate","Interdyne Lavaland Personnel")
 	},
 /turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
 /area/ruin/space/has_grav/nova/des_two/bridge/vault)
@@ -3424,7 +3424,7 @@
 "oG" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 5;
-	faction = list("Syndicate DS-2 Crew","neutral")
+	faction = list("Syndicate DS-2 Crew","Syndicate","Interdyne Lavaland Personnel")
 	},
 /turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
 /area/ruin/space/has_grav/nova/des_two/security/armory)
@@ -4971,7 +4971,7 @@
 /area/ruin/space/has_grav/nova/des_two/engineering)
 "vS" = (
 /obj/machinery/porta_turret/syndicate/energy{
-	faction = list("Syndicate DS-2 Crew","Interdyne Lavaland Personnel")
+	faction = list("Syndicate DS-2 Crew","Syndicate","Interdyne Lavaland Personnel")
 	},
 /turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
 /area/ruin/space/has_grav/nova/des_two/bridge/vault)
@@ -8516,7 +8516,7 @@
 "Mt" = (
 /obj/machinery/porta_turret/syndicate/energy{
 	dir = 5;
-	faction = list("Syndicate DS-2 Crew","Interdyne Lavaland Personnel")
+	faction = list("Syndicate DS-2 Crew","Syndicate","Interdyne Lavaland Personnel")
 	},
 /turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
 /area/ruin/space/has_grav/nova/des_two/bridge/vault)
@@ -10539,7 +10539,7 @@
 "VG" = (
 /obj/machinery/porta_turret/syndicate/energy{
 	dir = 4;
-	faction = list("Syndicate DS-2 Crew","Interdyne Lavaland Personnel")
+	faction = list("Syndicate DS-2 Crew","Syndicate","Interdyne Lavaland Personnel")
 	},
 /turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
 /area/ruin/space/has_grav/nova/des_two/bridge/vault)


### PR DESCRIPTION
## Описание
обновил фракции на турелях дса и интердайна, убрал хамелион мод у дек офицера интердайна заменив его на интердайновский, хамелион мод лежит в сейфе хранилища. добавил аннонсер на не обновленные ранее карты дса и интердайна


## Changelog

:cl:
map: Added more factions to ds-2 and interdyne turrets, removed neutral(techically almost everyone) faction from ds-2 armory turret
map: moved chameleon modsuit from icemoon interdyne deck officer room into vault's safe, deck officer gets interdyne modsuit
fix: fixed a missing interdyne and ds-2 announcer machine on maps
/:cl:


- [x] Проверено на локалке