### PR TITLE
fix: nonstation roles no longer sent to cryo

### DIFF
--- a/modular_ss220/modules/auto_cryo/autocryo.dm
+++ b/modular_ss220/modules/auto_cryo/autocryo.dm
@@ -9,6 +9,8 @@
 		var/turf/T = get_turf(src)
 		if(!is_station_level(T.z))
 			return
+		if (!mind || !mind.assigned_role || !(mind.assigned_role.job_flags & JOB_CREW_MEMBER))
+			return
 		send_to_cryo()
 
 /mob/living/carbon/Logout()


### PR DESCRIPTION
## Changelog

:cl:
fix: Non-initial station crewmembers are no longer sent to cryo when SSD long time outside of game
/:cl:

****
- [x] Проверено на локалке
