### PR TITLE
fix: away commconsole

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -240,7 +240,8 @@ GLOBAL_VAR_INIT(cops_arrived, FALSE)
 				return
 			make_announcement(user)
 		if ("messageAssociates")
-			if (!authenticated_as_ai_or_captain(user)) // NOVA EDIT CHANGE - Allows AI and Captain to send messages - ORIGINAL: if (!authenticated_as_non_silicon_captain(user))
+			if (!authenticated_as_ai_or_captain(user) && !away)	//SS1984 ADD
+		//	if (!authenticated_as_ai_or_captain(user)) // NOVA EDIT CHANGE - Allows AI and Captain to send messages - ORIGINAL: if (!authenticated_as_non_silicon_captain(user)) //SS1984 DISABLE
 				return
 			if (!COOLDOWN_FINISHED(src, important_action_cooldown))
 				return

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -33,12 +33,6 @@ GLOBAL_VAR_INIT(cops_arrived, FALSE)
 	/// Whether syndicate mode is enabled or not.
 	var/syndicate = FALSE
 
-	/// Whether away mode is enabled or not. ss1984 add
-	var/away = FALSE
-
-	/// Whether console can see  call 911 button or not. ss1984 add
-	var/can_call_911 = TRUE
-
 	/// The current state of the UI
 	var/state = STATE_MAIN
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -618,9 +618,9 @@ GLOBAL_VAR_INIT(cops_arrived, FALSE)
 				data["authorizeName"] = authorize_name
 				data["canLogOut"] = !HAS_SILICON_ACCESS(user)
 				data["shuttleCanEvacOrFailReason"] = SSshuttle.canEvac()
-
 				if(syndicate || away) //ss1984 edit original 'if(syndicate)'
 					data["shuttleCanEvacOrFailReason"] = "You cannot summon the shuttle from this console!"
+
 				if (authenticated_as_non_silicon_captain(user))
 					data["canMessageAssociates"] = TRUE
 					data["canRequestNuke"] = TRUE

--- a/modular_ss220/modules/communications_console/code/console.dm
+++ b/modular_ss220/modules/communications_console/code/console.dm
@@ -1,0 +1,6 @@
+/obj/machinery/computer/communications
+	/// Whether away mode is enabled or not.
+	var/away = FALSE
+
+	/// Whether console can see call 911 button or not.
+	var/can_call_911 = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9851,6 +9851,7 @@
 #include "modular_ss220\modules\localization_modular\ru_letters_crayon\code\crayon.dm"
 #include "modular_ss220\modules\changelog_highlight\changelog_highlight.dm"
 #include "modular_ss220\modules\changelog_highlight\changelog.dm"
+#include "modular_ss220\modules\communications_console\code\console.dm"
 #include "modular_ss220\modules\forbid_imprint_trim\job.dm"
 #include "modular_ss220\modules\disable_upstream_stuff\safety_additions.dm"
 #include "modular_ss220\modules\disable_upstream_stuff\no_default_nif_examine\nifs.dm"

--- a/tgui/packages/tgui/interfaces/CommunicationsConsole/Main.tsx
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole/Main.tsx
@@ -23,7 +23,7 @@ export function PageMain(props) {
     canToggleEngineeringOverride, // NOVA EDIT ADDITION - Engineering Override
     emagged,
     syndicate,
-    away, // ss1984 edit oldstation
+    away, // SS1984 EDIT - oldstation
     emergencyAccess,
     engineeringOverride, // NOVA EDIT ADDITION - Engineering Override
     importantActionReady,

--- a/tgui/packages/tgui/interfaces/CommunicationsConsole/Main.tsx
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole/Main.tsx
@@ -23,7 +23,7 @@ export function PageMain(props) {
     canToggleEngineeringOverride, // NOVA EDIT ADDITION - Engineering Override
     emagged,
     syndicate,
-    away, // SS1984 EDIT - oldstation
+    away, // ss1984 edit oldstation
     emergencyAccess,
     engineeringOverride, // NOVA EDIT ADDITION - Engineering Override
     importantActionReady,


### PR DESCRIPTION
## Описание
консоль связи вновь работает правильно для гост ролей(связь с админами) + передвинул код вара в модульную папку и передвинул пробел так как сейчас у оффов


## Changelog

:cl:
fix: away and away synd comm console properly work again
/:cl:

- [x] Проверено на локалке