### PR TITLE
fix: return missed service security officer preference

### DIFF
--- a/code/_globalvars/lists/department.dm
+++ b/code/_globalvars/lists/department.dm
@@ -4,4 +4,5 @@ GLOBAL_LIST_INIT(security_depts_prefs, sort_list(list(
 	SEC_DEPT_NONE,
 	SEC_DEPT_SCIENCE,
 	SEC_DEPT_SUPPLY,
+	SEC_DEPT_SERVICE, // CELADON ADDITION
 )))


### PR DESCRIPTION
## Changelog

:cl:
fix: Service security officer department preference is available again
/:cl:

****
- [x] Проверено на локалке
