### PR TITLE
del: Shoulder handgun holsters no longer wear below suit

### DIFF
--- a/modular_celadon/modules/security_minor_celadon/shoulder_holsters/shoulder_holster.dm
+++ b/modular_celadon/modules/security_minor_celadon/shoulder_holsters/shoulder_holster.dm
@@ -19,6 +19,9 @@
 	holstered = null
 	return ..()
 
+/obj/item/clothing/accessory/holster/attack_self_secondary(mob/user)
+	return TRUE // doesn't allow to wear "below" suit, as it's not working that way anyway
+
 //subtypes can override this to specify what can be holstered
 /obj/item/clothing/accessory/holster/proc/can_holster(obj/item/gun/W)
 	if(W.w_class > holster_allow_size)


### PR DESCRIPTION
## Changelog

:cl:
del: Shoulder handgun holster (those primary from Security Vouchers) no longer can be worn "below" suit, as they were not working that way anyway.
/:cl:

****
- [x] Проверено на локалке
