### PR TITLE
qol: detective wooden TV can be assembled

### DIFF
--- a/modular_celadon/modules/qol_casual_celadon/wooden_tv_construction/computer_circuitboards.dm
+++ b/modular_celadon/modules/qol_casual_celadon/wooden_tv_construction/computer_circuitboards.dm
@@ -1,0 +1,6 @@
+/obj/item/circuitboard/computer/security/wooden_tv
+	name = "Security Cameras Monitor"
+	build_path = /obj/machinery/computer/security/wooden_tv
+
+/obj/machinery/computer/security/wooden_tv
+	circuit = /obj/item/circuitboard/computer/security/wooden_tv

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9943,6 +9943,7 @@
 #include "modular_celadon\modules\qol_casual_celadon\cellcharger_power_desc\cell_charger.dm"
 #include "modular_celadon\modules\qol_casual_celadon\default_cyborg_namechange\robot.dm"
 #include "modular_celadon\modules\qol_casual_celadon\disable_some_holidays\holidays.dm"
+#include "modular_celadon\modules\qol_casual_celadon\wooden_tv_construction\computer_circuitboards.dm"
 #include "modular_celadon\modules\ghostroles_stuff\shuttles_stuff\shuttles.dm"
 #include "modular_celadon\modules\rust_g_custom\test.dm"
 #include "modular_celadon\modules\admin_stuff\man_up\admin.dm"


### PR DESCRIPTION
## Changelog

:cl:
qol: Detective wooden TV console can be assembled from circuit, instead of normal security camera console. The difference is only visual
/:cl:

****
- [x] Проверено на локалке
