### PR TITLE
del: remove connect to relay verb&button

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -19,11 +19,6 @@ menu "menu"
 		command = ".reconnect"
 		category = "&File"
 		saved-params = "is-checked"
-    elem
-		name = "&Connect to Relay"
-		command = "connect-to-relay"
-        category = "&File"
-		saved-params = "is-checked"
 	elem
 		name = "&Quit\tAlt-F4"
 		command = ".quit"

--- a/modular_nova/modules/verbs/code/relays.dm
+++ b/modular_nova/modules/verbs/code/relays.dm
@@ -7,6 +7,7 @@
 	splitter = ","
 
 /client/proc/connect_to_relay()
+/* CELADON REMOVAL START, keeping the proc name to avoid potential upstream issues
 	set name = "Connect to Relay"
 	set category = "OOC"
 	if(!CONFIG_GET(flag/enable_relays))
@@ -31,3 +32,4 @@
 	usr << link(address)
 	sleep(1 SECONDS)
 	winset(usr, null, "command=.quit")
+CELADON REMOVAL END */


### PR DESCRIPTION
## Changelog

:cl:
del: Remove "Connect to relay" option in "File" menu and OOC verb. They were not used anyway.
/:cl:

****
- [x] Проверено на локалке
