### PR TITLE
del: remove looc roll 20 from emotes

### DIFF
--- a/modular_nova/modules/emote_panel/code/emote_panel.dm
+++ b/modular_nova/modules/emote_panel/code/emote_panel.dm
@@ -8,7 +8,7 @@
 	var/static/list/mob_emotes = list(
 		/mob/proc/emote_flip,
 		/mob/proc/emote_spin,
-		/mob/proc/emote_rolld20,
+		// CELADON REMOVAL /mob/proc/emote_rolld20,
 	)
 	all_emotes += mob_emotes
 
@@ -292,10 +292,12 @@
 	set category = "Emotes"
 	usr.emote("spin", intentional = TRUE)
 
-/mob/proc/emote_rolld20()
-	set name = "| Roll 20 |"
-	set category = "Emotes"
-	usr.emote("rolld20", intentional = TRUE)
+// CELADON REMOVAL START
+// /mob/proc/emote_rolld20()
+	// set name = "| Roll 20 |"
+	// set category = "Emotes"
+	// usr.emote("rolld20", intentional = TRUE)
+// CELADON REMOVAL END
 // code\modules\mob\living\emote.dm
 
 /mob/living/proc/emote_blush()

--- a/modular_nova/modules/emotes/code/emotes.dm
+++ b/modular_nova/modules/emotes/code/emotes.dm
@@ -835,14 +835,16 @@
 /datum/emote/living/carbon/human/blink
 	sound = 'modular_nova/modules/emotes/sound/voice/blink.ogg'
 
-/datum/emote/rolld20
-	key = "rolld20"
-	affected_by_pitch = FALSE
+// CELADON REMOVAL START
+// /datum/emote/rolld20
+// 	key = "rolld20"
+// 	affected_by_pitch = FALSE
 
-/datum/emote/rolld20/run_emote(mob/user, params, type_override, intentional)
-	. = ..()
-	var/result = roll(20)
-	user.client?.looc_message("[user] rolls a d20 and gets [result].")
+// /datum/emote/rolld20/run_emote(mob/user, params, type_override, intentional)
+// 	. = ..()
+// 	var/result = roll(20)
+// 	user.client?.looc_message("[user] rolls a d20 and gets [result].")
+// CELADON REMOVAL END
 
 /datum/emote/living/mar
 	key = "mar"


### PR DESCRIPTION
## Changelog

:cl:
del: Roll 20 emote removed (it's just says text to LOOC that can be easily faked)
/:cl:

****
- [x] Проверено на локалке