### PR TITLE
spellcheck: localize and return silicon emotes

### DIFF
--- a/modular_celadon/modules/localization_modular/emotes_localization/emotes.dm
+++ b/modular_celadon/modules/localization_modular/emotes_localization/emotes.dm
@@ -586,3 +586,48 @@
 	name = "свистеть"
 	message = "свист%(ит,ят)%."
 	message_mime = "бесшумно свист%(ит,ят)%"
+
+// code\modules\mob\living\silicon\robot\emote.dm
+
+/datum/emote/silicon/boop
+	name = "буп"
+	message = "boops."
+
+/datum/emote/silicon/beep
+	name = "буп"
+	message = "бупает."
+	message_param = "бупает в сторону %t."
+
+/datum/emote/silicon/buzz
+	name = "жужжать"
+	message = "жужжит."
+	message_param = "жужжит в сторону %t."
+
+/datum/emote/silicon/buzz2
+	name = "раздражённо жужжать"
+	message = "раздражённо жужжит."
+
+/datum/emote/silicon/chime
+	name = "звенеть"
+	message = "звенит."
+
+/datum/emote/silicon/honk
+	name = "хонкать"
+	message = "хонкает."
+
+/datum/emote/silicon/ping
+	name = "сигналить"
+	message = "сигналит."
+	message_param = "сигналит в сторону %t."
+
+/datum/emote/silicon/sad
+	name = "звук грустного тромбон"
+	message = "играет грустный тромбон..."
+
+/datum/emote/silicon/warn
+	name = "звук предупреждения"
+	message = "издает предупреждающий звук!"
+
+/datum/emote/silicon/slowclap
+	name = "звук хлопания"
+	message = "проигрывает звук хлопания."

--- a/modular_celadon/modules/localization_modular/emotes_localization/emotes.dm
+++ b/modular_celadon/modules/localization_modular/emotes_localization/emotes.dm
@@ -591,15 +591,15 @@
 
 /datum/emote/silicon/boop
 	name = "буп"
-	message = "boops."
+	message = "бупает."
 
 /datum/emote/silicon/beep
-	name = "буп"
-	message = "бупает."
-	message_param = "бупает в сторону %t."
+	name = "бип"
+	message = "бипает."
+	message_param = "бипает в сторону %t."
 
 /datum/emote/silicon/buzz
-	name = "жужжать"
+	name = "звук жужжания"
 	message = "жужжит."
 	message_param = "жужжит в сторону %t."
 
@@ -621,7 +621,7 @@
 	message_param = "сигналит в сторону %t."
 
 /datum/emote/silicon/sad
-	name = "звук грустного тромбон"
+	name = "звук грустного тромбона"
 	message = "играет грустный тромбон..."
 
 /datum/emote/silicon/warn

--- a/modular_nova/modules/emote_panel/code/emote_panel.dm
+++ b/modular_nova/modules/emote_panel/code/emote_panel.dm
@@ -210,10 +210,23 @@
 	// 	/mob/living/proc/emote_warn,
 	// 	/mob/living/proc/emote_slowclap
 	// )
-	// all_emotes += synth_emotes
-	// var/static/list/allowed_species_synth = list(
-	// 	/datum/species/synthetic
-	// )
+	// CELADON ADDITION START
+	var/static/list/synth_emotes = list(
+		/mob/living/proc/emote_boop,
+		/mob/living/proc/emote_buzz,
+		/mob/living/proc/emote_beep,
+		/mob/living/proc/emote_chime,
+		/mob/living/proc/emote_honk,
+		/mob/living/proc/emote_ping,
+		/mob/living/proc/emote_sad,
+		/mob/living/proc/emote_warn,
+		/mob/living/proc/emote_slowclap
+	)
+	// CELADON ADDITION END
+	all_emotes += synth_emotes
+	var/static/list/allowed_species_synth = list(
+		/datum/species/synthetic
+	)
 	// Celadon REMOVAL END
 
 	// modular_nova\modules\emotes\code\additionalemotes\overlay_emote.dm
@@ -254,10 +267,10 @@
 			// available_emotes += nova_living_emotes
 			// available_emotes += nova_living_emotes_overlay
 			// available_emotes += /mob/living/proc/emote_mark_turf
-			// Checking if should apply Synth emotes
-			// if(HAS_TRAIT(src, TRAIT_SILICON_EMOTES_ALLOWED))
-			// 	available_emotes += synth_emotes
 			// Celadon REMOVAL END
+			// Checking if should apply Synth emotes
+			if(HAS_TRAIT(src, TRAIT_SILICON_EMOTES_ALLOWED))
+				available_emotes += synth_emotes
 		if(iscarbon(src))
 			available_emotes += carbon_emotes
 		if(ishuman(src))

--- a/modular_nova/modules/emote_panel/code/emote_panel.dm
+++ b/modular_nova/modules/emote_panel/code/emote_panel.dm
@@ -1070,21 +1070,22 @@ Celadon REMOVAL END */
 	set name = "< No >" // Celadon EDIT
 	set category = "Emotes"
 	usr.emote("no", intentional = TRUE)
-
+CELADON REMOVAL END*/
 /mob/living/proc/emote_boop()
-	set name = "< Boop >" // Celadon EDIT
+	set name = "< Буп >" // Celadon EDIT
 	set category = "Emotes"
 	usr.emote("boop", intentional = TRUE)
 
 /mob/living/proc/emote_buzz()
-	set name = "< Buzz >" // Celadon EDIT
+	set name = "< Звук жужжания >" // Celadon EDIT
 	set category = "Emotes"
 	usr.emote("buzz", intentional = TRUE)
 
 /mob/living/proc/emote_beep()
-	set name = "< Beep >" // Celadon EDIT
+	set name = "< Бип >" // Celadon EDIT
 	set category = "Emotes"
 	usr.emote("beep", intentional = TRUE)
+/* CELADON REMOVAL START
 
 /mob/living/proc/emote_beep2()
 	set name = "< Beep Sharply >" // Celadon EDIT
@@ -1096,36 +1097,37 @@ Celadon REMOVAL END */
 	set category = "Emotes"
 	usr.emote("buzz2", intentional = TRUE)
 
+CELADON REMOVAL END*/
+
 /mob/living/proc/emote_chime()
-	set name = "< Chime >" // Celadon EDIT
+	set name = "< Звенеть >" // Celadon EDIT
 	set category = "Emotes"
 	usr.emote("chime", intentional = TRUE)
 
 /mob/living/proc/emote_honk()
-	set name = "< Honk >" // Celadon EDIT
+	set name = "< Хонк >" // Celadon EDIT
 	set category = "Emotes"
 	usr.emote("honk", intentional = TRUE)
 
 /mob/living/proc/emote_ping()
-	set name = "< Ping >" // Celadon EDIT
+	set name = "< Сигналить >" // Celadon EDIT
 	set category = "Emotes"
 	usr.emote("ping", intentional = TRUE)
 
 /mob/living/proc/emote_sad()
-	set name = "< Sad >" // Celadon EDIT
+	set name = "< Звук грустного тромбона >" // Celadon EDIT
 	set category = "Emotes"
 	usr.emote("sad", intentional = TRUE)
 
 /mob/living/proc/emote_warn()
-	set name = "< Warn >" // Celadon EDIT
+	set name = "< Звук предупреждения >" // Celadon EDIT
 	set category = "Emotes"
 	usr.emote("warn", intentional = TRUE)
 
 /mob/living/proc/emote_slowclap()
-	set name = "< Slow Clap >" // Celadon EDIT
+	set name = "< Звук хлопания >" // Celadon EDIT
 	set category = "Emotes"
 	usr.emote("slowclap", intentional = TRUE)
-Celadon REMOVAL END */
 
 /* Celadon REMOVAL START
 


### PR DESCRIPTION
## Описание

Доделано несколько вещей из：
https://github.com/skyrat1984test/skyrat1984test/pull/432
https://github.com/skyrat1984test/skyrat1984test/pull/395

## Changelog

:cl:
add: Added removed earlier silicon emotes. Synthetics also can use them.
spellcheck: Silicon sounds localized
/:cl:
****
- [x] Проверено на локалке
