### PR TITLE
fix: Modular automapper & fix missing edits

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -12078,7 +12078,6 @@
 	pixel_x = 6
 	},
 /obj/item/reagent_containers/syringe,
-/obj/machinery/defibrillator_mount/loaded/directional/loaded/east,
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/large,
 /area/station/medical/treatment_center)
@@ -60692,16 +60691,6 @@
 /obj/effect/spawner/random/maintenance/no_decals/two,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
-"qUd" = (
-/obj/machinery/button/door/directional/west{
-	id = "engstorage";
-	name = "Engineering Secure Storage Control";
-	pixel_x = 4;
-	pixel_y = 4;
-	req_access = list("engine_equip")
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/engine_smes)
 "qUf" = (
 /obj/machinery/firealarm/directional/east,
 /obj/item/storage/box/bodybags{
@@ -66191,26 +66180,6 @@
 /obj/structure/sign/departments/cargo/directional/west,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"svq" = (
-/obj/structure/table/glass,
-/obj/item/stack/medical/gauze{
-	pixel_x = -2;
-	pixel_y = 8
-	},
-/obj/item/stack/medical/mesh{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/stack/medical/suture,
-/obj/item/reagent_containers/cup/bottle/epinephrine,
-/obj/item/reagent_containers/cup/bottle/multiver{
-	pixel_x = 6
-	},
-/obj/item/reagent_containers/syringe,
-/obj/machinery/defibrillator_mount/loaded/directional/east,
-/obj/effect/turf_decal/tile/blue/full,
-/turf/open/floor/iron/large,
-/area/station/medical/treatment_center)
 "svx" = (
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/blue{
@@ -82816,23 +82785,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
 /area/station/ai/satellite/atmos)
-"xpc" = (
-/obj/effect/turf_decal/siding/yellow/corner,
-/obj/machinery/status_display/evac/directional/south,
-/obj/structure/table,
-/obj/item/flatpack{
-	board = /obj/item/circuitboard/machine/flatpacker;
-	pixel_x = -5
-	},
-/obj/item/multitool{
-	pixel_x = 8
-	},
-/obj/item/stack/sheet/iron/ten,
-/obj/item/stack/sheet/glass{
-	amount = 10
-	},
-/turf/open/floor/iron,
-/area/station/engineering/lobby)
 "xpm" = (
 /obj/structure/chair/comfy/beige{
 	dir = 8
@@ -83677,10 +83629,6 @@
 	},
 /turf/open/floor/circuit/red,
 /area/station/ai/upload/chamber)
-"xAn" = (
-/obj/machinery/autolathe,
-/turf/open/floor/iron/dark,
-/area/station/engineering/lobby)
 "xAs" = (
 /turf/closed/wall/r_wall,
 /area/icemoon/surface/outdoors/nospawn)
@@ -243667,7 +243615,7 @@ mNY
 yaL
 rqF
 rqF
-qUd
+yaL
 yaL
 yaL
 yaL

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -60185,15 +60185,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"uzK" = (
-/obj/machinery/button/door/directional/west{
-	id = "Secure Storage";
-	name = "Engineering Secure Storage";
-	req_access = list("engine_equip");
-	pixel_x = 6
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/main)
 "uAg" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
@@ -111288,7 +111279,7 @@ mww
 kEs
 xsd
 uXd
-uzK
+uXd
 hnG
 hnG
 uXd

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -12918,16 +12918,6 @@
 /obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/floor/iron/dark,
 /area/station/medical/treatment_center)
-"dqk" = (
-/obj/machinery/button/door/directional/west{
-	name = "Engineering Secure Storage";
-	id = "Secure Storage";
-	req_access = list("engine_equip");
-	pixel_x = 0;
-	pixel_y = 6
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/engine_smes)
 "dqm" = (
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
@@ -27622,17 +27612,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/processing)
-"iOc" = (
-/obj/machinery/stasis{
-	dir = 8
-	},
-/obj/machinery/defibrillator_mount/loaded/directional/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/obj/machinery/vitals_reader/directional/east,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "iOi" = (
 /turf/open/floor/wood/large,
 /area/station/service/library)
@@ -53614,21 +53593,6 @@
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom/holding)
-"rNl" = (
-/obj/machinery/stasis{
-	dir = 4
-	},
-/obj/machinery/defibrillator_mount/loaded/directional/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/obj/machinery/camera/directional/west{
-	network = list("ss13","medbay");
-	c_tag = "Medical - Treatment North-West"
-	},
-/obj/machinery/vitals_reader/directional/west,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "rNt" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -101776,7 +101740,7 @@ pkp
 bTm
 bTm
 hRi
-dqk
+pkp
 anu
 voC
 doT

--- a/_maps/nova/automapper/automapper_config.toml
+++ b/_maps/nova/automapper/automapper_config.toml
@@ -140,6 +140,14 @@ required_map = "DeltaStation2.dmm"
 coordinates = [151, 175, 1]
 trait_name = "Station"
 
+# DELTA CELADON engineering storage
+[templates.deltastation_celadon_engineering_storage]
+map_files = ["deltastation_celadon_engineering_storage.dmm"]
+directory = "_maps/nova/automapper/templates/deltastation/"
+required_map = "DeltaStation2.dmm"
+coordinates = [102, 119, 1]
+trait_name = "Station"
+
 # ICEBOX MAP EDITS
 # Icebox Arrivals
 [templates.icebox_arrivals]

--- a/_maps/nova/automapper/automapper_config.toml
+++ b/_maps/nova/automapper/automapper_config.toml
@@ -83,6 +83,14 @@ required_map = "MetaStation.dmm"
 coordinates = [141, 149, 1]
 trait_name = "Station"
 
+# METASTATION CELADON engineering storage
+[templates.metastation_celadon_engineering_storage]
+map_files = ["metastation_celadon_engineering_storage.dmm"]
+directory = "_maps/nova/automapper/templates/metastation/"
+required_map = "MetaStation.dmm"
+coordinates = [157, 156, 1]
+trait_name = "Station"
+
 # DELTASTATION MAP EDITS
 # Deltastation Arrivals
 [templates.deltastation_arrivals]
@@ -237,6 +245,14 @@ required_map = "IceBoxStation.dmm"
 coordinates = [59, 143, 3]
 trait_name = "Station"
 
+# ICEBOX CELADON engineering storage
+[templates.icebox_celadon_engineering_storage]
+map_files = ["icebox_celadon_engineering_storage.dmm"]
+directory = "_maps/nova/automapper/templates/icebox/"
+required_map = "IceBoxStation.dmm"
+coordinates = [104, 78, 3]
+trait_name = "Station"
+
 # TRAMSTATION MAP EDITS
 # Tramstation Arrivals
 [templates.tramstation_arrivals]
@@ -292,6 +308,14 @@ map_files = ["tramstation_garden.dmm"]
 directory = "_maps/nova/automapper/templates/tramstation/"
 required_map = "tramstation.dmm"
 coordinates = [46, 109, 2]
+trait_name = "Station"
+
+# TRAM CELADON engineering storage
+[templates.tramstation_celadon_engineering_storage]
+map_files = ["tramstation_celadon_engineering_storage.dmm"]
+directory = "_maps/nova/automapper/templates/tramstation/"
+required_map = "tramstation.dmm"
+coordinates = [115, 99, 1]
 trait_name = "Station"
 
 # Lavaland NE Ashwalker Fortress

--- a/_maps/nova/automapper/templates/deltastation/deltastation_celadon_engineering_storage.dmm
+++ b/_maps/nova/automapper/templates/deltastation/deltastation_celadon_engineering_storage.dmm
@@ -1,0 +1,23 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/structure/sign/warning/secure_area/directional/east,
+/obj/machinery/button/door/directional/east{
+	name = "Engineering Secure Storage Control";
+	id = engstorage;
+	req_access = list("engine_equip");
+	pixel_y = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
+
+(1,1,1) = {"
+a
+"}

--- a/_maps/nova/automapper/templates/icebox/icebox_celadon_engineering_storage.dmm
+++ b/_maps/nova/automapper/templates/icebox/icebox_celadon_engineering_storage.dmm
@@ -1,0 +1,36 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/table,
+/obj/item/storage/box/lights/mixed,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stock_parts/power_store/cell/emproof,
+/obj/item/stock_parts/power_store/cell/emproof{
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/firealarm/directional/south{
+	pixel_x = 4
+	},
+/obj/machinery/light_switch/directional/south{
+	pixel_x = -5;
+	pixel_y = -27
+	},
+/obj/machinery/button/door/directional/west{
+	base_pixel_x = 4;
+	base_pixel_y = 4;
+	name = "Engineering Secure Storage Control";
+	id = "engstorage";
+	req_access = list("engine_equip")
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/engine_smes)
+
+(1,1,1) = {"
+a
+"}

--- a/_maps/nova/automapper/templates/metastation/metastation_celadon_engineering_storage.dmm
+++ b/_maps/nova/automapper/templates/metastation/metastation_celadon_engineering_storage.dmm
@@ -1,0 +1,17 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/table,
+/obj/item/airlock_painter,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/button/door/directional/west{
+	id = "engstorage";
+	name = "Engineering Secure Storage Control";
+	pixel_y = 6;
+	req_access = list("engine_equip")
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
+
+(1,1,1) = {"
+a
+"}

--- a/_maps/nova/automapper/templates/metastation/metastation_celadon_engineering_storage.dmm
+++ b/_maps/nova/automapper/templates/metastation/metastation_celadon_engineering_storage.dmm
@@ -4,7 +4,7 @@
 /obj/item/airlock_painter,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/button/door/directional/west{
-	id = "engstorage";
+	id = "Secure Storage";
 	name = "Engineering Secure Storage Control";
 	pixel_y = 6;
 	req_access = list("engine_equip")

--- a/_maps/nova/automapper/templates/tramstation/tramstation_celadon_engineering_storage.dmm
+++ b/_maps/nova/automapper/templates/tramstation/tramstation_celadon_engineering_storage.dmm
@@ -12,7 +12,7 @@
 /obj/structure/cable,
 /obj/machinery/button/door/directional/north{
 	req_access = list("engine_equip");
-	id = engstorage;
+	id = "Secure Storage";
 	name = "Engineering Secure Storage Control";
 	pixel_y = 25;
 	pixel_x = -10

--- a/_maps/nova/automapper/templates/tramstation/tramstation_celadon_engineering_storage.dmm
+++ b/_maps/nova/automapper/templates/tramstation/tramstation_celadon_engineering_storage.dmm
@@ -1,0 +1,25 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/north{
+	pixel_x = 6
+	},
+/obj/structure/cable,
+/obj/machinery/button/door/directional/north{
+	req_access = list("engine_equip");
+	id = engstorage;
+	name = "Engineering Secure Storage Control";
+	pixel_y = 25;
+	pixel_x = -10
+	},
+/turf/open/floor/iron,
+/area/station/engineering/engine_smes)
+
+(1,1,1) = {"
+a
+"}


### PR DESCRIPTION
## P.S.

Изначально пытался сделать отдельный automapper_config.toml, но похоже это полноценно не поддерживается (сыпались рантаймы, с модульного вообще не работали темплейты, но не исключено что я что-то недоделал, хоть и маловероятно)
Поэтому для наилучшей совместимости и снижения числа непонятных ошибок - все в конфиге и папке новы держим

## Changelog

:cl:
fix: Missing engineering secure storage button is added to maps that it had
/:cl:

****
- [x] Проверено на локалке
