### PR TITLE
fix: fixes error pizza

### DIFF
--- a/modular_celadon/modules/upstream-fixes/epizza/pizza.dm
+++ b/modular_celadon/modules/upstream-fixes/epizza/pizza.dm
@@ -1,0 +1,9 @@
+/obj/item/food/pizza
+	name = "pizza"
+	desc = "you eat this"
+	icon_state = "pizzamargherita"
+
+/obj/item/food/pizzaslice
+	name = "pizza slice"
+	desc = "you eat this"
+	icon_state = "pizzamargheritaslice"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9851,6 +9851,7 @@
 #include "modular_celadon\modules\upstream-fixes\split_slime_icon\living.dm"
 #include "modular_celadon\modules\upstream-fixes\dead_spawnable_races\dna.dm"
 #include "modular_celadon\modules\upstream-fixes\dice-no-rotation\fix_dice.dm"
+#include "modular_celadon\modules\upstream-fixes\epizza\pizza.dm"
 #include "modular_celadon\modules\vendors\code\dorms.dm"
 #include "modular_celadon\modules\restrict-species\restrict_species.dm"
 #include "modular_celadon\modules\disabled_station_traits\negative_traits.dm"


### PR DESCRIPTION
Убрать этот костыль после того, как ТГ полноценно починят, отслеживать следующие issue:

```
https://github.com/tgstation/tgstation/issues/95030
https://github.com/NovaSector/NovaSector/issues/5355
```

Изначально баг порожден этим (на самом деле, оригинальный автор скорее всего до конца не решил эту проблему, или вовсе ей не занимался, но от его изменений она стала заметна):

```
https://github.com/tgstation/tgstation/pull/94736
```

## Changelog

:cl:
fix: Error pizza now is normal pizza
/:cl:

****
- [x] Проверено на локалке
