### PR TITLE
balance:ore redemption machine upgrade buffs

### DIFF
--- a/modular_celadon/modules/cargo/code/mining/machine_redemption.dm
+++ b/modular_celadon/modules/cargo/code/mining/machine_redemption.dm
@@ -1,0 +1,22 @@
+#define BASE_POINT_MULT 1
+#define BASE_SHEET_MULT 1
+#define POINT_MULT_ADD_PER_RATING 0.1
+#define SHEET_MULT_ADD_PER_RATING 0.1
+
+/obj/machinery/mineral/ore_redemption/RefreshParts()
+	. = ..()
+	//servo increase points(+10% * (tier-1))
+	for(var/datum/stock_part/servo/S in component_parts)
+		point_upgrade = BASE_POINT_MULT + (POINT_MULT_ADD_PER_RATING * (S.tier - 1))
+	var/sheet_bonus = 0
+	//matter bin and laser increase ore mult(+5% laser, +5% matter)
+	for(var/datum/stock_part/matter_bin/B in component_parts)
+		sheet_bonus += BASE_SHEET_MULT + (SHEET_MULT_ADD_PER_RATING * (B.tier - 1))
+	for(var/datum/stock_part/micro_laser/M in component_parts)
+		sheet_bonus += BASE_SHEET_MULT + (SHEET_MULT_ADD_PER_RATING * (M.tier - 1))
+	ore_multiplier = sheet_bonus / 2
+
+#undef BASE_POINT_MULT
+#undef BASE_SHEET_MULT
+#undef POINT_MULT_ADD_PER_RATING
+#undef SHEET_MULT_ADD_PER_RATING

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9539,6 +9539,7 @@
 #include "modular_celadon\modules\auto_cryo\autocryo_config.dm"
 #include "modular_celadon\modules\cargo\code\_changes.dm"
 #include "modular_celadon\modules\cargo\code\_import_code.dm"
+#include "modular_celadon\modules\cargo\code\mining\machine_redemption.dm"
 #include "modular_celadon\modules\cargo\code\console.dm"
 #include "modular_celadon\modules\cargo\code\akh_frontier_celadon.dm"
 #include "modular_celadon\modules\cargo\code\deforest_medical_celadon.dm"


### PR DESCRIPTION
## Описание
печка теперь получает бафы от улучшенных деталей, формула очков 1(базовая эффективность) + 10%*(тир детали-1), для руды - так же, но для тех же 30 процентов нужно улучшить обе детали(канистра и лазер)


## Changelog

:cl:
balance: ore redemption machine now get buffs from better parts(servo increase points and matter bin + laser increase ore mult, max buff is +30%)
/:cl:

- [x] Проверено на локалке