### PR TITLE
code: inheritance support in restrict_species

### DIFF
--- a/modular_celadon/modules/restrict-species/restrict_species.dm
+++ b/modular_celadon/modules/restrict-species/restrict_species.dm
@@ -25,7 +25,10 @@
 		return FALSE // some broken mob?
 
 	var/species_str = "[species_type.type]"
-	for(var/typepath in restricted_species)
-		if(findtext(typepath, species_str))
+	var/species_len = length(species_str)
+	for (var/typepath in restricted_species)
+		if (species_len < length(typepath))
+			continue
+		if (findtext(species_str, typepath))
 			return FALSE
 	return TRUE

--- a/modular_celadon/modules/restrict-species/restrict_species.dm
+++ b/modular_celadon/modules/restrict-species/restrict_species.dm
@@ -24,6 +24,8 @@
 	if (!species_type)
 		return FALSE // some broken mob?
 
-	if ("[species_type.type]" in restricted_species) // no inheritance will be supported here, so be careful
-		return FALSE
+	var/species_str = "[species_type.type]"
+	for(var/typepath in restricted_species)
+		if(findtext(typepath, species_str))
+			return FALSE
 	return TRUE


### PR DESCRIPTION
Подтипы ограниченных видов `var/list/restricted_species` в рульсетах динамика (например Holosynth - `/datum/species/synthetic/holosynth`) будут также не доступны для выпадения антажки при ограничении для `/datum/species/synthetic`
Т.е. добавляется поддержка наследования

****
- [x] Проверено на локалке