### PR TITLE
fix: objects in stomach no longer have a acid sounds

### DIFF
--- a/code/__DEFINES/~celadon_defines/traits.dm
+++ b/code/__DEFINES/~celadon_defines/traits.dm
@@ -4,3 +4,5 @@
 #define TRAIT_CHAPEL_WEAKNESS "chapel_weakness"
 /// Ignores damage slowdown
 #define TRAIT_NO_DAMAGE_SLOWDOWN "no_damage_slowdown"
+/// Is object in stomach?
+#define TRAIT_IN_STOMACH "in_stomach"

--- a/code/datums/components/acid.dm
+++ b/code/datums/components/acid.dm
@@ -32,7 +32,8 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 	/// The proc used to handle the parent [/atom] when processing. TODO: Unify damage and resistance flags so that this doesn't need to exist!
 	var/datum/callback/process_effect
 
-/datum/component/acid/Initialize(acid_power = ACID_POWER_MELT_TURF, acid_volume = 50, acid_overlay = GLOB.acid_overlay, acid_particles = /particles/acid, turf_acid_ignores_mobs = FALSE)
+///datum/component/acid/Initialize(acid_power = ACID_POWER_MELT_TURF, acid_volume = 50, acid_overlay = GLOB.acid_overlay, acid_particles = /particles/acid, turf_acid_ignores_mobs = FALSE)	//CELADON REMOVE
+/datum/component/acid/Initialize(acid_power = ACID_POWER_MELT_TURF, acid_volume = 50, acid_overlay = GLOB.acid_overlay, acid_particles = /particles/acid, turf_acid_ignores_mobs = FALSE, use_sound = TRUE)	//CELADON ADD
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 
@@ -68,7 +69,9 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 	set_volume(acid_volume)
 	src.acid_overlay = acid_overlay
 
-	sizzle = new(atom_parent, TRUE)
+//	sizzle = new(atom_parent, TRUE)	//CELADON REMOVE
+	if(use_sound)	//CELADON ADD START
+		sizzle = new(atom_parent, TRUE)	//CELADON ADD END
 	if(acid_particles)
 		if (ismovable(parent))
 			var/atom/movable/movable_parent = parent
@@ -117,7 +120,8 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 		atom_parent.update_appearance()
 
 /// Averages corrosive power and sums volume.
-/datum/component/acid/InheritComponent(datum/component/new_comp, i_am_original, acid_power, acid_volume)
+//datum/component/acid/InheritComponent(datum/component/new_comp, i_am_original, acid_power, acid_volume)	//CELADON REMOVE
+/datum/component/acid/InheritComponent(datum/component/new_comp, i_am_original, acid_power, acid_volume, use_sound)	//CELADON ADD
 	if(!i_am_original)
 		return
 	acid_power = ((src.acid_power * src.acid_volume) + (acid_power * acid_volume)) / (src.acid_volume + acid_volume)

--- a/code/game/atom/atom_act.dm
+++ b/code/game/atom/atom_act.dm
@@ -183,8 +183,10 @@
  *
  * Default behaviour is to send [COMSIG_ATOM_ACID_ACT] and return
  */
-/atom/proc/acid_act(acidpwr, acid_volume)
-	SEND_SIGNAL(src, COMSIG_ATOM_ACID_ACT, acidpwr, acid_volume)
+///atom/proc/acid_act(acidpwr, acid_volume)	//CELADON REMOVE START
+//	SEND_SIGNAL(src, COMSIG_ATOM_ACID_ACT, acidpwr, acid_volume)	//CELADON REMOVE END
+/atom/proc/acid_act(acidpwr, acid_volume, use_sound)	//CELADON ADD START
+	SEND_SIGNAL(src, COMSIG_ATOM_ACID_ACT, acidpwr, acid_volume, use_sound)	//CELADON ADD END
 	return FALSE
 
 /**

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1018,8 +1018,19 @@
 
 /obj/item/acid_melt()
 	if(!QDELETED(src))
-		var/turf/T = get_turf(src)
-		var/obj/effect/decal/cleanable/molten_object/MO = new(T)
+//		var/turf/T = get_turf(src)	//CELADON REMOVE START
+//		var/obj/effect/decal/cleanable/molten_object/MO = new(T)	//CELADON REMOVE END
+		var/obj/effect/decal/cleanable/molten_object/MO	//CELADON ADD START
+		if(HAS_TRAIT(src, TRAIT_IN_STOMACH))
+			var/mob/living/carbon/C = src.loc
+			var/obj/item/organ/stomach/stomach
+			if(iscarbon(C))
+				stomach = C.get_organ_by_type(/obj/item/organ/stomach)
+			MO = new(C)
+			stomach?.consume_thing(MO)
+		else
+			var/turf/TURF = get_turf(src)
+			MO = new(TURF)	//CELADON ADD END
 		MO.pixel_x = rand(-16,16)
 		MO.pixel_y = rand(-16,16)
 		MO.desc = "Looks like this was \an [src] some time ago."

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1407,6 +1407,7 @@
  * * discover_after - if the item will be discovered after being chomped (FALSE will usually mean it was swallowed, TRUE will usually mean it was bitten into and discovered)
  */
 /obj/item/proc/on_accidental_consumption(mob/living/carbon/victim, mob/living/carbon/user, obj/item/source_item, discover_after = TRUE)
+	var/obj/item/organ/stomach/stomach = victim.get_organ_by_type(/obj/item/organ/stomach)	//CELADON ADD
 	if(get_sharpness() && force >= 5) //if we've got something sharp with a decent force (ie, not plastic)
 		INVOKE_ASYNC(victim, TYPE_PROC_REF(/mob, emote), "scream")
 		victim.visible_message(span_warning("[victim] looks like [victim.p_theyve()] just bit something they shouldn't have!"), \
@@ -1421,6 +1422,10 @@
 		if(QDELETED(src)) // in case trying to embed it caused its deletion (say, if it's DROPDEL)
 			return
 		source_item?.reagents?.add_reagent(/datum/reagent/blood, 2)
+		if(HAS_TRAIT(victim, TRAIT_VORACIOUS) && discover_after)
+			if(stomach?.consume_thing(src))
+				to_chat(victim, span_warning("You swallow painfully. [source_item? "Something was in \the [source_item]..." : ""]"))
+				return FALSE
 		return discover_after
 
 	if(custom_materials?.len) //if we've got materials, let's see what's in it
@@ -1456,13 +1461,23 @@
 		victim.adjust_disgust(33)
 		victim.visible_message(span_warning("[victim] looks like [victim.p_theyve()] just bitten into something hard."), \
 						span_warning("Eugh! Did I just bite into something?"))
+		if(HAS_TRAIT(victim, TRAIT_VORACIOUS) && discover_after)
+			stomach?.consume_thing(src)
+			return FALSE
 		return discover_after
+
+	if(HAS_TRAIT(victim, TRAIT_VORACIOUS) && w_class <= WEIGHT_CLASS_SMALL)
+		if(stomach?.consume_thing(src))
+			if(w_class == WEIGHT_CLASS_SMALL)
+				victim.losebreath += 2
+				to_chat(victim, span_warning("You swallow hard. [source_item? "Something small was in \the [source_item]..." : ""]"))
+			return FALSE
 
 	if(w_class > WEIGHT_CLASS_TINY) //small items like soap or toys that don't have mat datums
 		to_chat(victim, span_warning("[source_item? "Something strange was in \the [source_item]..." : "I just bit something strange..."] "))
 		return discover_after
 
-	var/obj/item/organ/stomach/stomach = victim.get_organ_by_type(/obj/item/organ/stomach)
+	//var/obj/item/organ/stomach/stomach = victim.get_organ_by_type(/obj/item/organ/stomach)	//CELADON DISABLE
 	if (stomach?.consume_thing(src))
 		victim.losebreath += 2
 		to_chat(victim, span_warning("You swallow hard. [source_item? "Something small was in \the [source_item]..." : ""]"))

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -107,13 +107,15 @@
 ///// ACID
 
 ///the obj's reaction when touched by acid
-/obj/acid_act(acidpwr, acid_volume)
+///obj/acid_act(acidpwr, acid_volume)	//CELADON REMOVE
+/obj/acid_act(acidpwr, acid_volume, use_sound)	//CELADON ADD
 	. = ..()
 	if((resistance_flags & UNACIDABLE) || (acid_volume <= 0) || (acidpwr <= 0))
 		return FALSE
 	if(QDELETED(src)) //NOVA EDIT: fix createanddestroy
 		return FALSE
-	AddComponent(/datum/component/acid, acidpwr, acid_volume, custom_acid_overlay || GLOB.acid_overlay)
+//	AddComponent(/datum/component/acid, acidpwr, acid_volume, custom_acid_overlay || GLOB.acid_overlay)	//CELADON REMOVE
+	AddComponent(/datum/component/acid, acidpwr, acid_volume, custom_acid_overlay || GLOB.acid_overlay, use_sound=use_sound)	//CELADON ADD
 	return TRUE
 
 ///called when the obj is destroyed by acid.

--- a/code/modules/surgery/organs/internal/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach/_stomach.dm
@@ -221,6 +221,7 @@
 	RegisterSignal(thing, COMSIG_MOVABLE_MOVED, PROC_REF(content_moved))
 	RegisterSignal(thing, COMSIG_QDELETING, PROC_REF(content_deleted))
 	LAZYADD(stomach_contents, thing)
+	ADD_TRAIT(thing, TRAIT_IN_STOMACH, src)	//CELADON ADD
 	thing.forceMove(owner || src) // We assert that if we have no owner, we will not be nullspaced
 	return TRUE
 
@@ -233,6 +234,8 @@
 	if(source.loc == src || source.loc == owner) // not in us? out da list then
 		return
 	LAZYREMOVE(stomach_contents, source)
+	if(HAS_TRAIT(source, TRAIT_IN_STOMACH))	//CELADON ADD START
+		REMOVE_TRAIT(source, TRAIT_IN_STOMACH, src)	//CELADON ADD END
 	UnregisterSignal(source, list(COMSIG_MOVABLE_MOVED, COMSIG_QDELETING))
 
 /obj/item/organ/stomach/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change)

--- a/code/modules/surgery/organs/internal/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach/_stomach.dm
@@ -297,9 +297,10 @@
 		if (SEND_SIGNAL(thing, COMSIG_ATOM_STOMACH_DIGESTED, src, owner, seconds_per_tick) & COMPONENT_CANCEL_DIGESTION)
 			continue
 		var/acid_pwr = stomach_acid_power(thing, seconds_per_tick)
-//		if (acid_pwr)	//CELADON REMOVE
-		if (acid_pwr && !(thing.resistance_flags & (UNACIDABLE | INDESTRUCTIBLE)))	//CELADON ADD
-			thing.acid_act(acid_pwr, 10)
+//		if (acid_pwr)	//CELADON REMOVE START
+//			thing.acid_act(acid_pwr, 10)	//CELADON REMOVE END
+		if (acid_pwr && !(thing.resistance_flags & (ACID_PROOF | INDESTRUCTIBLE)))	//CELADON ADD START
+			thing.acid_act(acid_pwr, 10, FALSE)	//CELADON ADD END
 
 		// If you have strong stomach you can eat glass, literally
 		if (!isitem(thing) || HAS_TRAIT(owner, TRAIT_STRONG_STOMACH))

--- a/code/modules/surgery/organs/internal/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach/_stomach.dm
@@ -297,7 +297,8 @@
 		if (SEND_SIGNAL(thing, COMSIG_ATOM_STOMACH_DIGESTED, src, owner, seconds_per_tick) & COMPONENT_CANCEL_DIGESTION)
 			continue
 		var/acid_pwr = stomach_acid_power(thing, seconds_per_tick)
-		if (acid_pwr)
+//		if (acid_pwr)	//CELADON REMOVE
+		if (acid_pwr && !(thing.resistance_flags & (UNACIDABLE | INDESTRUCTIBLE)))	//CELADON ADD
 			thing.acid_act(acid_pwr, 10)
 
 		// If you have strong stomach you can eat glass, literally

--- a/modular_celadon/modules/acid/code/acid.dm
+++ b/modular_celadon/modules/acid/code/acid.dm
@@ -1,0 +1,3 @@
+/datum/component/acid
+//does our component make sound if something is dissolving by acid?
+	var/use_sound = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9630,6 +9630,7 @@
 #include "modular_celadon\modules\access_console_buttons\card.dm"
 #include "modular_celadon\modules\access_console_buttons\cards_ids.dm"
 #include "modular_celadon\modules\access_upgrader\code\upgrader.dm"
+#include "modular_celadon\modules\acid\code\acid.dm"
 #include "modular_celadon\modules\add_memory\general_custom_memory.dm"
 #include "modular_celadon\modules\add_memory\mind.dm"
 #include "modular_celadon\modules\add_memory\mob.dm"


### PR DESCRIPTION
## Описание



## Changelog

:cl:
add: Added more checks in food eating for traits
fix: fixed stomach acid code by removing sound from acid
/:cl:

- [x] Проверено на локалке